### PR TITLE
Temporarily hard-code dashboard warning message about move to DW engine

### DIFF
--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -161,6 +161,11 @@ echo "Using: VER_CHE = $VER_CHE (SHA_CHE = $SHA_CHE)"
 # update version in package.json
 jq --arg VER_CHE "${VER_CHE}" '.version=$VER_CHE' package.json > package.json1; mv package.json1 package.json
 
+# temporary: hard code warning about migration; should be removed in next version
+WARNING_MESSAGE='The next release uses a new DevWorkspace engine, and existing workspaces will need to be converted to the new format. <a href="https://todo">Click here to learn how to update and migrate</a>'
+sed -i "/if (clusterConfig.dashboardWarning)/i \ \ \ \ \ \ \ \ clusterConfig.dashboardWarning =\n          '$MESSAGE';"\
+  ${TARGETDIR}/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
+
 SHA_CRW=$(cd ${TARGETDIR}; git rev-parse --short=4 HEAD)
 echo "Using: CRW_VERSION = $CRW_VERSION (SHA_CRW = $SHA_CRW)"
 


### PR DESCRIPTION
### Description
Hard code a warning message in the dashboard about the upcoming DevWorkspace engine migration. Message copy is still WIP and link is a TODO.

This is a really ugly solution, but my other attempts to do this ran into dead ends:
* The dashboard reads the warning message directly from the CheCluster custom resource, via the Kubernetes API, meaning the operator deployment has no interaction in the flow (i.e. the patch can't go in the codeready-workspaces-operator conversion)
* I tried setting a default value in the custom resource to set the warning, but
    * existing CheClusters will not get the default value applied (I think...)
    * even if they did, once set it would need to be manually un-set to undo the patch

Instead, this replacement just updates
```typescript
        if (clusterConfig.dashboardWarning) {
          dispatch(BannerAlertStore.actionCreators.addBanner(clusterConfig.dashboardWarning));
        }
```
to be
```typescript
        clusterConfig.dashboardWarning =
          'The next release uses a new DevWorkspace engine, and existing workspaces will need to be converted to the new format. <a href="https://docs-url">Click here to learn how to update and migrate</a>';
        if (clusterConfig.dashboardWarning) {
          dispatch(BannerAlertStore.actionCreators.addBanner(clusterConfig.dashboardWarning));
        }
```
though this has the downside that it would be impossible to _not_ display this message for whatever versions use this patch.