### PR TITLE
Hard-code warning message about move to DW but make it configurable

### DIFF
--- a/codeready-workspaces-dashboard/build/scripts/sync.sh
+++ b/codeready-workspaces-dashboard/build/scripts/sync.sh
@@ -164,7 +164,12 @@ jq --arg VER_CHE "${VER_CHE}" '.version=$VER_CHE' package.json > package.json1; 
 # https://issues.redhat.com/browse/CRW-2823 - add warning about migration to 3.y in 2.15.z
 LANDING_PAGE="https://developers.redhat.com/articles/2022/03/17/red-hat-openshift-dev-spaces-formerly-red-hat-codeready-workspaces-next-major"
 WARNING_MESSAGE='The next release uses a new DevWorkspace engine, and existing workspaces will need to be converted to the new format. <a href="'${LANDING_PAGE}'">Click here to learn how to update and migrate</a>'
-sed -i "/if (clusterConfig.dashboardWarning)/i \ \ \ \ \ \ \ \ clusterConfig.dashboardWarning =\n          '$MESSAGE';"\
+JS_SNIPPET="       if (!clusterConfig.dashboardWarning) {\n\
+          clusterConfig.dashboardWarning =\n\
+            '$WARNING_MESSAGE';\n\
+        }"
+
+sed -i "/if (clusterConfig.dashboardWarning)/i \ $JS_SNIPPET"\
   ${TARGETDIR}/packages/dashboard-frontend/src/store/ClusterConfig/index.ts
 
 SHA_CRW=$(cd ${TARGETDIR}; git rev-parse --short=4 HEAD)


### PR DESCRIPTION
Rework https://github.com/redhat-developer/devspaces-images/pull/204 so that deprecation warning can be overridden.

Showing default warning message:
![dashboard-warning-new](https://user-images.githubusercontent.com/16168279/159312105-0504e9c4-4991-442a-8c6f-44c729a6c35d.png)

Default warning message when the frontend can't connect to the backend:
![dashboard-warning-new-stack](https://user-images.githubusercontent.com/16168279/159312164-89fa175b-6e0f-4575-9d41-515b3664a6bd.png)

Overriding warning message:
![dashboard-warning-override](https://user-images.githubusercontent.com/16168279/159312192-2fc641cb-c7c4-447d-bfdb-86a107c8464b.png)

Overriding warning message with empty string (banner still shows up by is smaller and contains no text):
![dashboard-warning-override-empty](https://user-images.githubusercontent.com/16168279/159312251-a6599128-372c-4338-b27e-2c041fe4916d.png)


Diff from script applied to on dashboard 7.42.x: https://github.com/amisevsk/che-dashboard/commit/08d88a4b6386aeb6f5faa253533f4b31fabde958