### PR TITLE
fix: CRW-2848 hardcode server-rhel8:2.15-20 in 2.15.3 CSVs

### DIFF
--- a/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
+++ b/codeready-workspaces-operator-bundle/manifests/codeready-workspaces.csv.yaml
@@ -1126,7 +1126,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: RELATED_IMAGE_che_server
-                        value: registry.redhat.io/codeready-workspaces/server-rhel8:2.15
+                        value: registry.redhat.io/codeready-workspaces/server-rhel8:2.15-20
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
                         value: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8:2.15
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts

--- a/codeready-workspaces-operator-metadata/manifests/codeready-workspaces.csv.yaml
+++ b/codeready-workspaces-operator-metadata/manifests/codeready-workspaces.csv.yaml
@@ -1126,7 +1126,7 @@ spec:
                           fieldRef:
                             fieldPath: metadata.name
                       - name: RELATED_IMAGE_che_server
-                        value: registry.redhat.io/codeready-workspaces/server-rhel8:2.15
+                        value: registry.redhat.io/codeready-workspaces/server-rhel8:2.15-20
                       - name: RELATED_IMAGE_che_server_secure_exposer_jwt_proxy_image
                         value: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8:2.15
                       - name: RELATED_IMAGE_che_workspace_plugin_broker_artifacts


### PR DESCRIPTION
### What does this PR do?

CRW-2848 hardcode the image reference for server to registry.redhat.io/codeready-workspaces/server-rhel8:2.15-20 instead of registry.redhat.io/codeready-workspaces/server-rhel8:2.15, which resolves to 2.15-19.1646248955, which fixes some CVE but undoes fix for CRW-2739 in https://github.com/eclipse-che/che-server/pull/264 / https://github.com/eclipse-che/che-server/pull/260

Change-Id: I7832788c7ae9b2a77c0f61980f5776151a5f98a2
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2848
https://issues.redhat.com/browse/CRW-2739

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.