### PR TITLE
fix:cleanup entrypoint.sh for UDI

### DIFF
--- a/devspaces-udi/etc/entrypoint.sh
+++ b/devspaces-udi/etc/entrypoint.sh
@@ -53,13 +53,13 @@ fi
 # Use java 8 ONLY if USE_JAVA8 is set to 'true'
 #############################################################################
 if [ "${USE_JAVA8}" == "true" ] && [ ! -z "${JAVA8_HOME}" ]; then
-  export JAVA_HOME=${JAVA8_HOME}
-  export PATH="${JAVA8_HOME}/bin:${PATH}"
+  echo "JAVA_HOME=${JAVA8_HOME}" >> "${HOME}"/.bashrc
+  echo "PATH=${JAVA8_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
   echo "Java environment set to ${JAVA8_HOME}"
 else
   if [ ! -z "${JAVA11_HOME}" ]; then
-    export JAVA_HOME=${JAVA11_HOME}
-    export PATH="${JAVA11_HOME}/bin:${PATH}"
+    echo "JAVA_HOME=${JAVA11_HOME}" >> "${HOME}"/.bashrc
+    echo "PATH=${JAVA11_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
     echo "Java environment set to ${JAVA11_HOME}"
   else
     echo "Java environment is not configured"

--- a/devspaces-udi/etc/entrypoint.sh
+++ b/devspaces-udi/etc/entrypoint.sh
@@ -55,19 +55,11 @@ fi
 if [ "${USE_JAVA8}" == "true" ] && [ ! -z "${JAVA8_HOME}" ]; then
   export JAVA_HOME=${JAVA8_HOME}
   export PATH="${JAVA8_HOME}/bin:${PATH}"
-  sudo rm -f /etc/alternatives/java
-  sudo ln -s ${JAVA8_HOME}/bin/java /etc/alternatives/java
-  sudo rm -f /etc/alternatives/javac
-  sudo ln -s ${JAVA8_HOME}/bin/javac /etc/alternatives/javac
   echo "Java environment set to ${JAVA8_HOME}"
 else
   if [ ! -z "${JAVA11_HOME}" ]; then
     export JAVA_HOME=${JAVA11_HOME}
     export PATH="${JAVA11_HOME}/bin:${PATH}"
-    sudo rm -f /etc/alternatives/java
-    sudo ln -s ${JAVA11_HOME}/bin/java /etc/alternatives/java
-    sudo rm -f /etc/alternatives/javac
-    sudo ln -s ${JAVA11_HOME}/bin/javac /etc/alternatives/javac
     echo "Java environment set to ${JAVA11_HOME}"
   else
     echo "Java environment is not configured"

--- a/devspaces-udi/etc/entrypoint.sh
+++ b/devspaces-udi/etc/entrypoint.sh
@@ -53,13 +53,13 @@ fi
 # Use java 8 ONLY if USE_JAVA8 is set to 'true'
 #############################################################################
 if [ "${USE_JAVA8}" == "true" ] && [ ! -z "${JAVA8_HOME}" ]; then
-  echo "JAVA_HOME=${JAVA8_HOME}" >> "${HOME}"/.bashrc
-  echo "PATH=${JAVA8_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
+  echo "export JAVA_HOME=${JAVA8_HOME}" >> "${HOME}"/.bashrc
+  echo "export PATH=${JAVA8_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
   echo "Java environment set to ${JAVA8_HOME}"
 else
   if [ ! -z "${JAVA11_HOME}" ]; then
-    echo "JAVA_HOME=${JAVA11_HOME}" >> "${HOME}"/.bashrc
-    echo "PATH=${JAVA11_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
+    echo "export JAVA_HOME=${JAVA11_HOME}" >> "${HOME}"/.bashrc
+    echo "export PATH=${JAVA11_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
     echo "Java environment set to ${JAVA11_HOME}"
   else
     echo "Java environment is not configured"


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

It's not possible to execute commands with **sudo** in entrypoint.sh. Can we proceed without removing unused _/etc/alternatives/java_ and _/etc/alternatives/javac_?

Fix for https://issues.redhat.com/browse/CRW-2862