### PR TITLE
chore: add a mechanism to set java version at runtime

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -29,7 +29,8 @@ ENV \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
     JAVA11_HOME=/usr/lib/jvm/java-11-openjdk \
     JAVA8_HOME=/usr/lib/jvm/java-1.8.0-openjdk \
-    PATH="$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/opt/apache-maven/bin:/opt/gradle/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
+    JAVA_HOME="${HOME}/.java/current" \
+    PATH="${HOME}/.java/current/bin:$HOME/node_modules/.bin/:$HOME/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/opt/apache-maven/bin:/opt/gradle/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
     MANPATH="/usr/share/man:${MANPATH}" \
     JAVACONFDIRS="/etc/java${JAVACONFDIRS:+:}${JAVACONFDIRS:-}" \
     XDG_CONFIG_DIRS="/etc/xdg:${XDG_CONFIG_DIRS:-/etc/xdg}" \
@@ -86,6 +87,8 @@ RUN \
 RUN \
     dnf -y -q install java-1.8.0-openjdk java-1.8.0-openjdk-devel java-1.8.0-openjdk-headless \
     java-11-openjdk java-11-openjdk-devel java-11-openjdk-src java-11-openjdk-headless && \
+    mkdir -p ${HOME}/.java/current && \
+    rm -f /usr/bin/java && \
     # BEGIN copy from https://catalog.redhat.com/software/containers/ubi8/nodejs-12/5d3fff015a13461f5fb8635a?container-tabs=dockerfile
     dnf -y -q module reset nodejs && \
     dnf -y -q module enable nodejs:$NODEJS_VERSION && \

--- a/devspaces-udi/etc/entrypoint.sh
+++ b/devspaces-udi/etc/entrypoint.sh
@@ -53,13 +53,11 @@ fi
 # Use java 8 ONLY if USE_JAVA8 is set to 'true'
 #############################################################################
 if [ "${USE_JAVA8}" == "true" ] && [ ! -z "${JAVA8_HOME}" ]; then
-  echo "export JAVA_HOME=${JAVA8_HOME}" >> "${HOME}"/.bashrc
-  echo "export PATH=${JAVA8_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
+  ln -s "${JAVA8_HOME}"/* "${HOME}"/.java/current
   echo "Java environment set to ${JAVA8_HOME}"
 else
   if [ ! -z "${JAVA11_HOME}" ]; then
-    echo "export JAVA_HOME=${JAVA11_HOME}" >> "${HOME}"/.bashrc
-    echo "export PATH=${JAVA11_HOME}/bin:${PATH}" >> "${HOME}"/.bashrc
+    ln -s "${JAVA11_HOME}"/* "${HOME}"/.java/current
     echo "Java environment set to ${JAVA11_HOME}"
   else
     echo "Java environment is not configured"


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

1. At build time: set JAVA_HOME as **home/user/.java/current** and add it to PATH
2. At runtime: create symlink to java which is needed, by default it's java 11 

Fix for https://issues.redhat.com/browse/CRW-2878