### PR TITLE
feat: update docs location

### DIFF
--- a/devspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json
+++ b/devspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json
@@ -19,13 +19,12 @@
     }
   ],
   "docs": {
-    "devfile" : "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/end-user_guide/index#configuring-a-workspace-with-dashboard_devspaces",
-    "workspace" : "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/end-user_guide/index#developer-workspaces_devspaces",
+    "devfile" : "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/user_guide#customizing-workspaces",
+    "workspace" : "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/user_guide#developer-workspaces",
     "converting": "https://devfile.io/docs/devfile/2.1.0/user-guide/migrating-to-devfile-v2/",
-    "certificate": "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/end-user_guide/index#importing-certificates-to-browsers_devspaces",
     "general": "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/",
-    "storageTypes": "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/installation_guide/index#configuring-storage-types_devspaces",
-    "webSocketTroubleshooting": "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/end-user_guide/index#troubleshooting-network-problems_devspaces"
+    "storageTypes": "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/administration_guide#configuring-storage",
+    "webSocketTroubleshooting": "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/3.0/html-single/user_guide#troubleshooting-network-problems"
   },
   "configuration": {
     "cheCliTool": "dsc"


### PR DESCRIPTION
fix https://issues.redhat.com/browse/RHDEVDOCS-3928

Note: I assume the "certificate" link is not present in the dashboard. We have removed this piece of documentation as obsolete.