### PR TITLE
fix: CRW-2887 - when running update_container_image_references(), process meta.yaml and devworkspace-che-theia-latest.yaml too

### DIFF
--- a/devspaces-devfileregistry/build/dockerfiles/entrypoint.sh
+++ b/devspaces-devfileregistry/build/dockerfiles/entrypoint.sh
@@ -215,21 +215,21 @@ function update_container_image_references() {
   readarray -t devfiles < <(find "${DEVFILES_DIR}" -name 'devfile.yaml')
   readarray -t metas < <(find "${DEVFILES_DIR}" -name 'meta.yaml')
   readarray -t templates < <(find "${DEVFILES_DIR}" -name 'devworkspace-che-theia-latest.yaml')
-  for devfile in "${devfiles[@]}"; do
-    echo "Checking devfile $devfile"
+  for file in "${devfiles[@]}" "${metas[@]}" "${templates[@]}"; do
+    echo "Checking $file"
     # Need to update each field separately in case they are not defined.
     # Defaults don't work because registry and tags may be different.
     if [ -n "$REGISTRY" ]; then
-      echo "    Updating image registry to $REGISTRY"
-      sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$devfile"
+      echo "    Update image registry to $REGISTRY"
+      sed -i -E "s|image:$IMAGE_REGEX|image:\1${REGISTRY}/\3/\4\5:\6\7|" "$file"
     fi
     if [ -n "$ORGANIZATION" ]; then
-      echo "    Updating image organization to $ORGANIZATION"
-      sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$devfile"
+      echo "    Update image organization to $ORGANIZATION"
+      sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/${ORGANIZATION}/\4\5:\6\7|" "$file"
     fi
     if [ -n "$TAG" ]; then
-      echo "    Updating image tag to $TAG"
-      sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$devfile"
+      echo "    Update image tag to $TAG"
+      sed -i -E "s|image:$IMAGE_REGEX|image:\1\2/\3/\4:${TAG}\7|" "$file"
     fi
   done
 }

--- a/devspaces-operator-bundle/build/scripts/insert-related-images-to-csv.sh
+++ b/devspaces-operator-bundle/build/scripts/insert-related-images-to-csv.sh
@@ -52,8 +52,8 @@ tmpdir=$(mktemp -d); mkdir -p $tmpdir; pushd $tmpdir >/dev/null
     git checkout ${MIDSTM_BRANCH} || true
     cd ..
 
-    # collect containers referred to by devfiles
-    DEVFILE_REGISTRY_CONTAINERS="${DEVFILE_REGISTRY_CONTAINERS} $(cd devspaces/dependencies/che-devfile-registry; ./build/scripts/list_referenced_images.sh devfiles/)"
+    # collect containers referred to by devfiles, including generated devworkspace-che-theia-latest.yaml files that reference theia/endpoint/machineexec images (CRW-2887)
+    DEVFILE_REGISTRY_CONTAINERS="${DEVFILE_REGISTRY_CONTAINERS} $(cd devspaces/dependencies/che-devfile-registry; ./build/scripts/generate_devworkspace_templates.sh; ./build/scripts/list_referenced_images.sh devfiles/)"
 
     # collect containers referred to by plugins, but only the latest CRW_VERSION ones (might have older variants we don't need to include)
     PLUGIN_REGISTRY_CONTAINERS="${PLUGIN_REGISTRY_CONTAINERS} $(cd devspaces/dependencies/che-plugin-registry; ./build/scripts/list_referenced_images.sh ./ | grep ${CRW_VERSION})"


### PR DESCRIPTION
### What does this PR do?

fix: CRW-2887 - when running update_container_image_references(), process meta.yaml and devworkspace-che-theia-latest.yaml too

Change-Id: I5afc03584be8b6e1a606f60a69e07737c8381ec5
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.