### PR TITLE
Improve sed by adding check for ubi8 image

### DIFF
--- a/devspaces-idea/build/scripts/sync.sh
+++ b/devspaces-idea/build/scripts/sync.sh
@@ -83,7 +83,7 @@ sed_in_place() {
 
 sed_in_place -r \
   `# Remove registry so build works in Brew` \
-  -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/#FROM #g" \
+  -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/(ubi8/)?#FROM #g" \
   `# Remove unused Python packages (support for PyCharm not included in CRW)` \
   -e "/python2 python39 \\\\/d" \
   "${TARGETDIR}"/Dockerfile


### PR DESCRIPTION
Improve sed instruction to avoid having `ubi8/ubi:8.5-214 as ubi-builder`. Improved command provides correct image for Brew build: `FROM ubi:8.5-214 as ubi-builder`

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>