### PR TITLE
Fix sed command for ubi8 image name

### DIFF
--- a/devspaces-idea/build/scripts/sync.sh
+++ b/devspaces-idea/build/scripts/sync.sh
@@ -82,8 +82,10 @@ sed_in_place() {
 }
 
 sed_in_place -r \
+  `# Update ubi8 image name` \
+  -e "s#ubi8/ubi:#ubi8:#g" \
   `# Remove registry so build works in Brew` \
-  -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/(ubi8/)?#FROM #g" \
+  -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/#FROM #g" \
   `# Remove unused Python packages (support for PyCharm not included in CRW)` \
   -e "/python2 python39 \\\\/d" \
   "${TARGETDIR}"/Dockerfile


### PR DESCRIPTION
Fix sed instruction to change name for ubi8 image from:
```
FROM registry.access.redhat.com/ubi8/ubi:8.5-214 as ubi-builder
```
to
```
FROM ubi8:8.5-214 as ubi-builder
```

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>