### PR TITLE
Add e2fsprogs bundle for x86 platform

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -23,6 +23,7 @@ ENV \
     LOMBOK_VERSION="1.18.22" \
     PYTHON_VERSION="3.8" \
     PHP_VERSION="7.3" \
+    E2FSPROGS_VERSION="1.46.5" \
     LD_LIBRARY_PATH="/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
     CPATH="/usr/include${CPATH:+:${CPATH}}" \
     DOTNET_RPM_VERSION=3.1 \
@@ -46,7 +47,7 @@ RUN mkdir -p /home/user /projects
 COPY . /tmp/assets/
 COPY etc/docker.sh /usr/local/bin/docker
 COPY lombok-${LOMBOK_VERSION}.jar /lombok.jar
-COPY gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz /tmp/
+COPY gradle-${GRADLE_VERSION}-bin.zip apache-maven-${MAVEN_VERSION}-bin.tar.gz e2fsprogs-${E2FSPROGS_VERSION}.tar.gz /tmp/
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io or registry.access.redhat.com
 # enable rhel 8 content sets (from Brew) to resolve buildah
@@ -196,6 +197,27 @@ RUN \
     mkdir -p ${HOME}/che/ls-php/php-language-server && \
     tar xzf /tmp/assets/asset-php-$(uname -m).tar.gz -C ${HOME}/che/ls-php/php-language-server/ && \
     cp ${HOME}/che/ls-php/php-language-server/composer/composer /usr/bin/composer
+RUN \
+    ########################################################################
+    # e2fsprogs (x64 only) (Tech Preview)
+    ########################################################################
+    if [[ "$(uname -m)" == 'x86_64' ]]; then \
+        TEMP_DIR="$(mktemp -d)" \
+        cd "${TEMP_DIR}" \
+        mv /tmp/e2fsprogs-${E2FSPROGS_VERSION}.tar.gz . \
+        tar -zxvf e2fsprogs-${E2FSPROGS_VERSION}.tar.gz \
+        cd "e2fsprogs-${E2FSPROGS_VERSION}" \
+        mkdir build \
+        cd build \
+        ../configure --prefix=/usr --with-root-prefix="" --enable-elf-shlibs --disable-evms \
+        make \
+        make install \
+        make install-libs \
+        cd -- \
+        rm -rf "${TEMP_DIR}" \
+    else \
+        rm /tmp/e2fsprogs-${E2FSPROGS_VERSION}.tar.gz
+    fi
     ########################################################################
     # Cleanup and Summaries
     ########################################################################

--- a/devspaces-udi/get-sources.sh
+++ b/devspaces-udi/get-sources.sh
@@ -14,6 +14,7 @@ GRADLE_VERSION="6.1"
 MAVEN_VERSION="3.6.3"
 LOMBOK_VERSION="1.18.22"
 ODO_VERSION="v2.5.0"
+E2FSPROGS_VERSION="1.46.5"
 ASSET_NAME="udi"
 
 while [[ "$#" -gt 0 ]]; do
@@ -90,8 +91,9 @@ if [[ $(diff -U 0 --suppress-common-lines -b Dockerfile.2 Dockerfile) ]] || [[ $
 	curl -sSL -O http://mirror.csclub.uwaterloo.ca/apache/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
 	curl -sSL -O https://github.com/redhat-developer/devspaces-images/releases/download/${CSV_VERSION}-${ASSET_NAME}-assets/lombok-${LOMBOK_VERSION}.jar
 	curl -sSL -O https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip
+	curl -sSL -O https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v${E2FSPROGS_VERSION}/e2fsprogs-${E2FSPROGS_VERSION}.tar.gz
 
-    outputFiles="$(ls asset-*.tar.gz) gradle-${GRADLE_VERSION}-bin.zip lombok-${LOMBOK_VERSION}.jar apache-maven-${MAVEN_VERSION}-bin.tar.gz asset-odo.tgz"
+    outputFiles="$(ls asset-*.tar.gz) gradle-${GRADLE_VERSION}-bin.zip lombok-${LOMBOK_VERSION}.jar apache-maven-${MAVEN_VERSION}-bin.tar.gz asset-odo.tgz e2fsprogs-${E2FSPROGS_VERSION}.tar.gz"
 
 	# cleanup
 	rm -f Dockerfile.2 uploadAssetsToGHRelease.sh


### PR DESCRIPTION
Port changes from upstream https://github.com/devfile/developer-images/commit/9436df267516e12b96fb59b4b12814c70ecdf558 to downstream UDI.

Build `e2fsprogs` for x86 only as far as this library is required for IntelliJ IDEA Community Edition and it runs only on x86 platform.

Part of https://issues.redhat.com/browse/CRW-2977

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>