### PR TITLE
Update IC tarball to 2022.1 version

### DIFF
--- a/devspaces-idea/get-sources.sh
+++ b/devspaces-idea/get-sources.sh
@@ -10,7 +10,7 @@ forceBuild=0
 # so that rhpkg build is simply a brew wrapper (using get-sources.sh -f)
 PULL_ASSETS=0
 
-idePackagingUrl=https://download-cdn.jetbrains.com/idea/ideaIC-2020.3.4.tar.gz
+idePackagingUrl=https://download-cdn.jetbrains.com/idea/ideaIC-2022.1.tar.gz
 
 while [[ "$#" -gt 0 ]]; do
 	case $1 in


### PR DESCRIPTION
Use IntelliJ IDEA Community Edition 2022.1 instead 2020.3.4

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>