### PR TITLE
fix: remove meta.yaml if devfile.yaml.${arch} exists

### DIFF
--- a/devspaces-devfileregistry/build/scripts/swap_yamlfiles.sh
+++ b/devspaces-devfileregistry/build/scripts/swap_yamlfiles.sh
@@ -18,18 +18,11 @@ yamlfiles=$("$SCRIPT_DIR"/list_yaml.sh "$YAML_ROOT")
 
 # shellcheck disable=SC2086
 for yamlfile in $yamlfiles ; do
-  if [[ -e ${yamlfile}.${arch} ]] ; then
-      mv ${yamlfile} ${yamlfile}.orig
-      mv ${yamlfile}.${arch} ${yamlfile}
-      echo "[INFO] swapped to $arch version of ${yamlfile}.${arch}"
-  fi
-
-  # remove empty
-  if [[ ! -s ${yamlfile} ]] ; then
+  if [[ -e "$(dirname $yamlfile)/devfile.yaml.${arch}" ]] ; then
     mv ${yamlfile} ${yamlfile}.removed
     if [[ -e "$(dirname $yamlfile)/meta.yaml" ]] ; then
       mv "$(dirname $yamlfile)/meta.yaml" "$(dirname $yamlfile)/meta.yaml.removed"
     fi
-    echo "[INFO] removed empty yamlfile ${yamlfile}"
+    echo "[INFO] removed yamlfile ${yamlfile}"
   fi
 done


### PR DESCRIPTION
I am not sure if changes from https://github.com/redhat-developer/devspaces/pull/739 will be synced automatically.

What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-3034