### PR TITLE
Re-enable the 'replaces' directive in 'devspaces-operator-bundle' build

### DIFF
--- a/devspaces-operator-bundle/build/scripts/sync-che-olm.sh
+++ b/devspaces-operator-bundle/build/scripts/sync-che-olm.sh
@@ -304,9 +304,7 @@ for CSVFILE in ${TARGETDIR}/manifests/devspaces.csv.yaml; do
 
 	# insert replaces: field
 	declare -A spec_insertions=(
-		# TODO CRW-2725 when CRW 3.0 is live, re-enable the replaces directive instead of this deletion
-		[".spec.replaces"]="DELETEME"
-		# [".spec.replaces"]="devspacesoperator.v${CSV_VERSION_PREV}"
+		[".spec.replaces"]="devspacesoperator.v${CSV_VERSION_PREV}"
 		[".spec.version"]="${CSV_VERSION}"
 		['.spec.displayName']="Red Hat OpenShift Dev Spaces"
 		['.metadata.annotations.description']="Devfile v2 and v1 development solution, 1 instance per cluster, for portable, collaborative k8s workspaces."

--- a/devspaces-operator-bundle/build/scripts/sync.sh
+++ b/devspaces-operator-bundle/build/scripts/sync.sh
@@ -21,8 +21,7 @@ CRW_VERSION=${CSV_VERSION%.*} # tag 3.y
 UPSTM_NAME="operator"
 MIDSTM_NAME="operator-bundle"
 
-# TODO CRW-2725 when CRW 3.0 is live, set CSV_VERSION_PREV="" to pull values from RHEC below
-CSV_VERSION_PREV="NONE"
+CSV_VERSION_PREV=""
 
 usage () {
     echo "


### PR DESCRIPTION
This PR modifies `devspaces-operator-bundle` build scripts to re-enable the 'replaces' directive in csv:
- sync-che-olm.sh
- sync.sh

It's related to https://issues.redhat.com/browse/CRW-2725

Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>