### PR TITLE
Keep deploy folder

### DIFF
--- a/devspaces-operator-bundle/build/scripts/sync-che-operator.sh
+++ b/devspaces-operator-bundle/build/scripts/sync-che-operator.sh
@@ -255,7 +255,6 @@ rm -f "${TARGETDIR}/${OPERATOR_DEPLOYMENT_YAML}2"
 echo "Converted (yq #4) ${OPERATOR_DEPLOYMENT_YAML}"
 
 # delete unneeded files
-rm -rf "${TARGETDIR}/deploy"
 rm -rf "${TARGETDIR}/cmd"
 rm -rf "${TARGETDIR}/pkg/apis"
 rm -rf "${TARGETDIR}/pkg/controller"

--- a/devspaces-operator/build/scripts/sync-che-operator.sh
+++ b/devspaces-operator/build/scripts/sync-che-operator.sh
@@ -248,7 +248,6 @@ rm -f "${TARGETDIR}/${OPERATOR_DEPLOYMENT_YAML}2"
 echo "Converted (yq #4) ${OPERATOR_DEPLOYMENT_YAML}"
 
 # delete unneeded files
-rm -rf "${TARGETDIR}/deploy"
 rm -rf "${TARGETDIR}/cmd"
 rm -rf "${TARGETDIR}/pkg/apis"
 rm -rf "${TARGETDIR}/pkg/controller"


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

Wee need deploy folder. It contains resources for chectl/dsc.
To fix build https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/CRW_CI/job/dsc_3.x/