### PR TITLE
chore: don't copy yarn.lock

### DIFF
--- a/devspaces-pluginregistry/bootstrap.Dockerfile
+++ b/devspaces-pluginregistry/bootstrap.Dockerfile
@@ -25,7 +25,7 @@ RUN /tmp/rhel.install.sh && rm -f /tmp/rhel.install.sh
 RUN npm install --global yarn
 
 # Copy files needed for the plugin registry build/artifact creation
-COPY ./build.sh ./*.yml ./*.yaml ./*.js ./*.json ./yarn.lock /build/
+COPY ./build.sh ./*.yml ./*.yaml ./*.js ./*.json /build/
 COPY ./build /build/build/
 
 # Run plugin registry build to generate artifacts


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

Don't copy non existing files

Related issue: https://issues.redhat.com/browse/CRW-3110