### PR TITLE
fix: Use github token at building libc docker image

### DIFF
--- a/devspaces-code/build/scripts/collect-assets.sh
+++ b/devspaces-code/build/scripts/collect-assets.sh
@@ -34,7 +34,7 @@ DOCKERFILES_PATH="${BASE_DIR_PATH}/build/dockerfiles"
 
 #### linux-libc-content ####
 collect_linux_libc_content_assets() {
-    docker build -f "${DOCKERFILES_PATH}/linux-libc.Dockerfile" -t $LIBC_BUILDER_IMAGE .
+    docker build -f "${DOCKERFILES_PATH}/linux-libc.Dockerfile" --build-arg GITHUB_TOKEN=$GITHUB_TOKEN -t $LIBC_BUILDER_IMAGE .
     docker build -f "${DOCKERFILES_PATH}/libc-content-provider.Dockerfile" -t $LIBC_CONTENT_IMAGE .
 
     id="$(docker create $LIBC_CONTENT_IMAGE)"


### PR DESCRIPTION
Use github token at building libc docker image.
The corresponding PR in the upstream is: https://github.com/che-incubator/che-code/pull/66

The changes should fix errors like:

```
23:39:26 23:39:26  GET https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/v13.0.0-4
23:39:26 23:39:26  Deleting invalid download cache
23:39:26 23:39:26  Downloading ripgrep failed: Error: Request failed: 403
23:39:26 23:39:26      at ClientRequest.<anonymous> (/checode-compilation/node_modules/@vscode/ripgrep/lib/download.js:143:24)
23:39:26 23:39:26      at Object.onceWrapper (node:events:640:26)
23:39:26 23:39:26      at ClientRequest.emit (node:events:520:28)
23:39:26 23:39:26      at HTTPParser.parserOnIncomingClient (node:_http_client:618:27)
23:39:26 23:39:26      at HTTPParser.parserOnHeadersComplete (node:_http_common:128:17)
23:39:26 23:39:26      at TLSSocket.socketOnData (node:_http_client:482:22)
23:39:26 23:39:26      at TLSSocket.emit (node:events:520:28)
23:39:26 23:39:26      at addChunk (node:internal/streams/readable:315:12)
23:39:26 23:39:26      at readableAddChunk (node:internal/streams/readable:289:9)
23:39:26 23:39:26      at TLSSocket.Readable.push (node:internal/streams/readable:228:10)
23:40:48 23:40:48  Error: error building at STEP "RUN yarn install --force": error while running runtime: exit status 1 
```

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>