### PR TITLE
Use x86_64 platform only for Code

### DIFF
--- a/devspaces-code/container.yaml
+++ b/devspaces-code/container.yaml
@@ -4,8 +4,8 @@ platforms:
 
   only:
     - x86_64   # can be a list (as here) or a string (as below)
-    - s390x
-    - ppc64le
+#    - s390x
+#    - ppc64le
 
 compose:
   inherit: false


### PR DESCRIPTION
Use x86_64 platform only for Code

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>