### PR TITLE
Add debug log for Code

### DIFF
--- a/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
+++ b/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
@@ -55,6 +55,8 @@ RUN yarn config set network-timeout 600000 -g
 # Grab dependencies (and force to rebuild them)
 RUN yarn install --force
 
+RUN echo "$(ulimit -a)"
+
 # Compile
 RUN NODE_ARCH=$(echo "console.log(process.arch)" | node) \
     && NODE_VERSION=$(cat /checode-compilation/remote/.yarnrc | grep target | cut -d ' ' -f 2 | tr -d '"') \


### PR DESCRIPTION
Add debug log for Code dockerfile

I got an error:
`20:53:02 20:53:02  [17:53:02] 'vscode-reh-web-linux-x64-min' errored after 5.18 min
20:53:02 20:53:02  [17:53:02] Error: EMFILE: too many open files, open '/checode-compilation/node_modules/jest-worker/build/workers/threadChild.js'`

So, I would like to add that log, maybe it could clarify the cause of the problem...

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>