### PR TITLE
fix: Fix build of docker image on brew

### DIFF
--- a/devspaces-code/Dockerfile
+++ b/devspaces-code/Dockerfile
@@ -31,6 +31,8 @@ RUN for f in "/mnt/rootfs/bin/" "/mnt/rootfs/home/che" "/mnt/rootfs/etc/passwd" 
            chmod -R g+rwX ${f}; \
        done
 
+RUN rm /mnt/rootfs/etc/hosts
+
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM ubi8-minimal:8.6-854
 COPY --from=ubi-builder /mnt/rootfs/ /


### PR DESCRIPTION
Fix build of docker image on brew

We get an error like:

```
16:26:18 16:26:18  2022-07-14 13:26:11,037 - atomic_reactor.plugins.imagebuilder - INFO - API error (500): Error processing tar file(exit status 1): remove /etc/hosts: device or resource busy
16:26:18 16:26:18  2022-07-14 13:26:11,040 - atomic_reactor.plugin - ERROR - Build step plugin imagebuilder failed: image build failed (rc=1): API error (500): Error processing tar file(exit status 1): remove /etc/hosts: device or resource busy
``` 
at building docker image on brew.

There is no such problem when we build the same image locally, but it's really a problem for brew...

The change should fix the problem. 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>