### PR TITLE
chore: print default java version

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -232,9 +232,14 @@ RUN \
     chmod -R g+rwX ${HOME} && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages" && \
     echo "========" && \
+    echo -n "Default Java Version:  "; java -version; \
+    echo "========" && \
     echo -n "Java 1.8:  "; /usr/lib/jvm/java-1.8.0-openjdk/bin/java -version; \
+    echo "========" && \
     echo -n "Java 11:  "; /usr/lib/jvm/java-11-openjdk/bin/java -version; \
+    echo "========" && \
     echo -n "Java 17:  "; /usr/lib/jvm/java-17-openjdk/bin/java -version; \
+    echo "========" && \
     echo -n "mvn:   "; mvn -version; \
     echo -n "gradle:    "; gradle -v; \
     echo "========" && \


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>
Print the default Java version during the build of UDI

The output is:
```
#7 0.294 ========
#7 0.294 Default Java Version:  openjdk version "11.0.15" 2022-04-19 LTS
#7 0.324 OpenJDK Runtime Environment 18.9 (build 11.0.15+10-LTS)
#7 0.324 OpenJDK 64-Bit Server VM 18.9 (build 11.0.15+10-LTS, mixed mode, sharing)
#7 0.328 ========
#7 0.328 Java 1.8:  openjdk version "1.8.0_332"
#7 0.384 OpenJDK Runtime Environment (build 1.8.0_332-b09)
#7 0.384 OpenJDK 64-Bit Server VM (build 25.332-b09, mixed mode)
#7 0.387 ========
#7 0.387 Java 11:  openjdk version "11.0.15" 2022-04-19 LTS
#7 0.415 OpenJDK Runtime Environment 18.9 (build 11.0.15+10-LTS)
#7 0.415 OpenJDK 64-Bit Server VM 18.9 (build 11.0.15+10-LTS, mixed mode, sharing)
#7 0.418 ========
#7 0.418 Java 17:  openjdk version "17.0.3" 2022-04-19 LTS
#7 0.436 OpenJDK Runtime Environment 21.9 (build 17.0.3+7-LTS)
#7 0.436 OpenJDK 64-Bit Server VM 21.9 (build 17.0.3+7-LTS, mixed mode, sharing)
#7 0.439 ========
```