### PR TITLE
Set namespace: openshift-devspaces in CheCluster

### DIFF
--- a/devspaces-operator-bundle/manifests/devspaces.csv.yaml
+++ b/devspaces-operator-bundle/manifests/devspaces.csv.yaml
@@ -23,7 +23,7 @@ metadata:
           "kind": "CheCluster",
           "metadata": {
             "name": "devspaces",
-            "namespace": "devspaces"
+            "namespace": "openshift-devspaces"
           },
           "spec": {
             "auth": {


### PR DESCRIPTION
There is wrong default namespace in CheCluster CRD: "devspaces"
Correct one: "openshift-devspaces".