### PR TITLE
Enable 390x platform for building Code images

### DIFF
--- a/devspaces-code/container.yaml
+++ b/devspaces-code/container.yaml
@@ -4,9 +4,7 @@ platforms:
 
   only:
     - x86_64   # can be a list (as here) or a string (as below)
-    # TODO re-enable when CRW-3171 is fixed and support for BE exists (or a workaround is found)
-    # - s390x
-    # TODO re-enable when CRW-3153 is fixed and we can run podman on ppc-006 box
+    - s390x
     - ppc64le
 
 compose:


### PR DESCRIPTION
Enable 390x platform for building Code images

https://issues.redhat.com/browse/CRW-3171

[These changes](https://github.com/che-incubator/che-code/commit/4dcc762243664ecc7a40a33b981d4d98dc237528) should fix build for Code on `s390x` platform

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>