### PR TITLE
Update Traefik to 2.8.1

### DIFF
--- a/devspaces-traefik/build/scripts/sync.sh
+++ b/devspaces-traefik/build/scripts/sync.sh
@@ -17,7 +17,7 @@ set -e
 # defaults
 CSV_VERSION=2.y.0 # csv 2.y.0
 DS_VERSION=${CSV_VERSION%.*} # tag 2.y
-TRAEFIK_VERSION="v2.5.0"
+TRAEFIK_VERSION="v2.8.1"
 GOLANG_VERSION="1.16.2"
 UPSTM_NAME="traefik"
 MIDSTM_NAME="traefik"


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-3136

@nickboldt new plan, instead of updating 700 files I'm going to update the sync script to 2.8.1 then build devspaces-traefik in jenkins and let _that_ do the heavy lifting. 