### PR TITLE
feat: install pip in UDI

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -33,7 +33,7 @@ ENV \
     JAVA_HOME_11=/usr/lib/jvm/java-11-openjdk \
     JAVA_HOME_8=/usr/lib/jvm/java-1.8.0-openjdk \
     JAVA_HOME="/home/user/.java/current" \
-    PATH="/home/user/.java/current/bin:/home/user/node_modules/.bin/:/home/user/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/opt/apache-maven/bin:/opt/gradle/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
+    PATH="/home/user/.local/bin:/home/user/.java/current/bin:/home/user/node_modules/.bin/:/home/user/.npm-global/bin/:/opt/app-root/src/.npm-global/bin/:/opt/apache-maven/bin:/opt/gradle/bin:/usr/bin:${PATH:-/bin:/usr/bin}" \
     MANPATH="/usr/share/man:${MANPATH}" \
     JAVACONFDIRS="/etc/java${JAVACONFDIRS:+:}${JAVACONFDIRS:-}" \
     XDG_CONFIG_DIRS="/etc/xdg:${XDG_CONFIG_DIRS:-/etc/xdg}" \
@@ -137,7 +137,11 @@ RUN \
     for f in /tmp/py-unpack; do chgrp -R 0 ${f}; chmod -R g+rwX ${f}; done; \
     for d in bin lib lib64; do cp -R /tmp/py-unpack/${d}/* /usr/${d}; done; \
     cp -R /tmp/py-unpack/.venv ${HOME} && chgrp -R 0 ${HOME}/.venv && chmod -R g+rwX ${HOME}/.venv && \
-    rm -fr /tmp/py-unpack
+    rm -fr /tmp/py-unpack && \
+    # pip
+    mkdir -p ${HOME}/.cache/pip && chmod -R g+rwX ${HOME}/.cache/pip && \
+    python -m pip install --upgrade pip && \
+    pip install pytest
 RUN \
     # python/pip/pylint symlinks
     echo "Create python symlinks (or display existing ones) ==>" && \


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>
- Install pip with version 22.2.2
- Install pytest
- Add `/home/user/.local/bin` into PATH

Related issues:
- https://issues.redhat.com/browse/CRW-2630
- https://issues.redhat.com/browse/CRW-1927