### PR TITLE
fix: Remove unneeded GOPATH for UDI image

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -39,8 +39,7 @@ ENV \
     XDG_CONFIG_DIRS="/etc/xdg:${XDG_CONFIG_DIRS:-/etc/xdg}" \
     XDG_DATA_DIRS="/usr/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}" \
     M2_HOME="/opt/apache-maven" \
-    PKG_CONFIG_PATH="/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" \
-    GOPATH=/projects/.che/gopath
+    PKG_CONFIG_PATH="/usr/lib64/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}"
 
 ADD etc/storage.conf $HOME/.config/containers/storage.conf
 


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

this GOPATH definition is not needed, since we rely on default GOPATH pointing to /home/user/go