### PR TITLE
CRW-3312 - don't use Che UDI image in DS;...

### DIFF
--- a/devspaces-operator-bundle/build/scripts/sync-che-olm.sh
+++ b/devspaces-operator-bundle/build/scripts/sync-che-olm.sh
@@ -322,6 +322,10 @@ for CSVFILE in ${TARGETDIR}/manifests/devspaces.csv.yaml; do
 	fi
 done
 
+# https://issues.redhat.com/browse/CRW-3312 replace upstream UDI image with downstream one for the current DS version (tag :3.yy)
+sed -r -e "s#quay.io/devfile/universal-developer-image.+#registry.redhat.io/devspaces/udi-rhel8:${DS_VERSION}#g" -i \
+	"${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml"
+
 cp "${TARGETDIR}/bundle/${OLM_CHANNEL}/eclipse-che-preview-openshift/manifests/org.eclipse.che_checlusters.yaml" "${TARGETDIR}/manifests/devspaces.crd.yaml"
 
 popd >/dev/null || exit

--- a/devspaces-operator-bundle/manifests/devspaces.crd.yaml
+++ b/devspaces-operator-bundle/manifests/devspaces.crd.yaml
@@ -2206,7 +2206,7 @@ spec:
                     workspaceDefaultComponents:
                       default:
                         - container:
-                            image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                            image: registry.redhat.io/devspaces/udi-rhel8:3.3
                           name: universal-developer-image
                       description: Default components applied to DevWorkspaces. These
                         default components are meant to be used when a Devfile does
@@ -5541,7 +5541,7 @@ spec:
                   default:
                     defaultComponents:
                       - container:
-                          image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                          image: registry.redhat.io/devspaces/udi-rhel8:3.3
                         name: universal-developer-image
                     defaultEditor: eclipse/che-theia/latest
                     defaultNamespace:
@@ -5556,7 +5556,7 @@ spec:
                     defaultComponents:
                       default:
                         - container:
-                            image: quay.io/devfile/universal-developer-image:ubi8-38da5c2
+                            image: registry.redhat.io/devspaces/udi-rhel8:3.3
                           name: universal-developer-image
                       description: Default components applied to DevWorkspaces. These
                         default components are meant to be used when a Devfile, that


### PR DESCRIPTION
### What does this PR do?

CRW-3312 - don't use Che UDI image in DS; use the DS UDI image for the current version/tag
not sure if this will work as we generally pin digests, not tags in the CSV... but this is the CRD. Unclear how this is used and why we need to reference related images in the CRD as well as the CSV.

Anyway, this is a quick fix, but not sure if it'll work.

Change-Id: I9e08e8dfdf956b267e6236d3db09573c947cd592
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.