### PR TITLE
feat: CRW-3531 update to gopls 0.10.1 (was...

### DIFF
--- a/devspaces-udi/container.yaml
+++ b/devspaces-udi/container.yaml
@@ -19,12 +19,12 @@ compose:
 image_build_method: imagebuilder
 remote_sources:
 
-# https://issues.redhat.com/browse/CRW-3103 use gopls 0.7.2 as that's the latest version that can be built with go 1.17
-# https://github.com/golang/tools/releases?q=v0.7.2&expanded=true ==> https://github.com/golang/tools/commit/fd02dfae644ce04dfd4bb3828cf576b9d8717f79
+# https://issues.redhat.com/browse/CRW-3531 use gopls 0.10.1 as we can now build with go 1.18
+# https://github.com/golang/tools/releases/tag/gopls%2Fv0.10.1 ==> https://github.com/golang/tools/commit/8321f7bbcfd30300762661ed9188226b42e27ec1
 - name: gopls
   remote_source:
     repo: https://github.com/golang/tools
-    ref: 52c42e1da769f237f1b28ff5a2db3242292f6afb
+    ref: 8321f7bbcfd30300762661ed9188226b42e27ec1
     pkg_managers:
       - gomod
     packages: {"gomod": [{"path": "."}, {"path": "gopls"}]}


### PR DESCRIPTION
### What does this PR do?

feat: CRW-3531 update to gopls 0.10.1 (was 0.7.2)

Change-Id: I45e8c819b3c462ddd3828f28eb5c574153e93296
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.