### PR TITLE
chore: CRW-3159 remove dotnet 3.1 (EOL Dec 13, 2022 - see https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core)

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -250,12 +250,12 @@ RUN \
     echo "clangd -pretty" > ${HOME}/che/ls-clangd/launch.sh && \
     chmod +x ${HOME}/che/ls-clangd/launch.sh && \
     ########################################################################
-    # .NET (dotnet) 3.1 (x64 only) + 6.0 (s390x and x64 only) + 7.0 (ppc64le, s390x and x64 only) (Tech Preview)
+    # .NET (dotnet) 6.0 (s390x and x64 only) + 7.0 (ppc64le, s390x and x64 only) (Tech Preview)
     ########################################################################
-    # TODO: dotnet 3.1 is deprecated and will hit EOL Dec 13, 2022. See https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
-    # TODO: remove dotnet 3.1 from Dev Spaces 3.4 release - see https://issues.redhat.com/browse/CRW-3159
+    # TODO: dotnet 6 will EOL Nov 12, 2024 - see https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
+    # TODO: dotnet 7 will EOL May 14, 2024 - see https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core
     if [[ "$(uname -m)" == 'x86_64' ]]; then \
-        dnf -y -q --setopt=tsflags=nodocs install dotnet dotnet-sdk-6.0 dotnet-sdk-7.0 dotnet-sdk-3.1; \
+        dnf -y -q --setopt=tsflags=nodocs install dotnet dotnet-sdk-6.0 dotnet-sdk-7.0; \
     elif [[ "$(uname -m)" == 's390x' ]]; then \
         dnf -y -q --setopt=tsflags=nodocs install dotnet dotnet-sdk-6.0 dotnet-sdk-7.0; \
     elif [[ "$(uname -m)" == 'ppc64le' ]]; then \


### PR DESCRIPTION
### What does this PR do?

chore: CRW-3159 remove dotnet 3.1 (EOL Dec 13, 2022 - see https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) (#382)

Change-Id: Ic739716dbe343ab57485da08c46d02750ccd19f9
Signed-off-by: Nick Boldt <nboldt@redhat.com>

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.