### PR TITLE
chore: don't add lombok.jar into UDI

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -93,8 +93,6 @@ ADD etc/storage.conf $HOME/.config/containers/storage.conf
 ADD etc/entrypoint.sh /entrypoint.sh
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 COPY etc/docker.sh /usr/local/bin/docker
-# see fetch-artifacts-pnc.yaml
-COPY artifacts/lombok.jar /lombok.jar
 
 # NOTE: uncomment for local build. Must also set full registry path in FROM to registry.redhat.io or registry.access.redhat.com
 # enable rhel 8 content sets (from Brew) to resolve buildah

--- a/devspaces-udi/fetch-artifacts-pnc.yaml
+++ b/devspaces-udi/fetch-artifacts-pnc.yaml
@@ -1,9 +1,0 @@
-builds:
-  # https://orch.psi.redhat.com/pnc-web/#/projects/1076/build-configs/6637/builds/AODBO5YQY3AAA/dependencies
-  # build id must be string
-  - build_id: 'AODBO5YQY3AAA' 
-    artifacts:
-      # https://orch.psi.redhat.com/pnc-web/#/artifacts/6984449
-      # artifact id must be string; rename it by setting a different target path/file
-      - id: '6984449'
-        target: lombok.jar


### PR DESCRIPTION
Signed-off-by: Valerii Svydenko <vsvydenk@redhat.com>

Since VSCode redhat.java extension doesn't require the path to lombok.jar we can avoid adding lombok.jar into UDI 

Related issue: https://issues.redhat.com/browse/CRW-3602 