### PR TITLE
Set replacing version 3.3.0-0.1673528130.p in CSV

### DIFF
--- a/devspaces-operator-bundle-generated/manifests/devspaces.csv.yaml
+++ b/devspaces-operator-bundle-generated/manifests/devspaces.csv.yaml
@@ -1268,7 +1268,7 @@ spec:
     targetPort: 9443
     type: ConversionWebhook
     webhookPath: /convert
-  replaces: devspacesoperator.v3.3.0
+  replaces: devspacesoperator.v3.3.0-0.1673528130.p
   relatedImages:
   - name: devspaces-rhel8-operator-64e8ffa1b79951fc1b0a2cd27c686da8792da8227ccee3f4cbda588100a5e7c5-annotation
     image: registry.redhat.io/devspaces/devspaces-rhel8-operator@sha256:64e8ffa1b79951fc1b0a2cd27c686da8792da8227ccee3f4cbda588100a5e7c5


### PR DESCRIPTION
Fix an upgrade from DS 3.3.0 to DS 3.4.0 by setting `replaces: devspacesoperator.v3.3.0-0.1673528130.p` in CSV, after freshmaker had released DS 3.3.0+0.1673528130.p

Related issue: https://issues.redhat.com/projects/CRW/issues/CRW-3876