### PR TITLE
Remove vscode main endpoint path

### DIFF
--- a/devspaces-pluginregistry/che-editors.yaml
+++ b/devspaces-pluginregistry/che-editors.yaml
@@ -330,7 +330,6 @@ editors:
                 cookiesAuthEnabled: true
                 discoverable: false
                 urlRewriteSupported: true
-              path: '?tkn=eclipse-che'
               targetPort: 3100
               exposure: public
               secure: true


### PR DESCRIPTION
### What does this PR do?

It removes the unneeded security token for che-code main endpoint.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/21772
https://github.com/eclipse-che/che-plugin-registry/pull/1562
