### PR TITLE
Provide Dev Spaces label for the 'Restart Workspace' action

### DIFF
--- a/devspaces-code/branding/product.json
+++ b/devspaces-code/branding/product.json
@@ -21,6 +21,7 @@
 	"remoteIndicatorCommands": {
 		"openDocumentationCommand": "Dev Spaces: Open Documentation",
 		"openDashboardCommand": "Dev Spaces: Open Dashboard",
-		"stopWorkspaceCommand": "Dev Spaces: Stop Workspace"
+		"stopWorkspaceCommand": "Dev Spaces: Stop Workspace",
+		"restartWorkspaceCommand": "Dev Spaces: Restart Workspace"
 	}
 }


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

`Restart Workspace action was added in the upstream, see https://github.com/che-incubator/che-code/pull/172.
The current PR provides `Dev Spaces` label for the `Restart Workspace` action.