### PR TITLE
Provide Dev Spaces label for the 'Restart Workspace from Local Devfile' action

### DIFF
--- a/devspaces-code/branding/product.json
+++ b/devspaces-code/branding/product.json
@@ -22,6 +22,7 @@
 		"openDocumentationCommand": "Dev Spaces: Open Documentation",
 		"openDashboardCommand": "Dev Spaces: Open Dashboard",
 		"stopWorkspaceCommand": "Dev Spaces: Stop Workspace",
-		"restartWorkspaceCommand": "Dev Spaces: Restart Workspace"
+		"restartWorkspaceCommand": "Dev Spaces: Restart Workspace",
+		"restartWorkspaceFromLocalDevfileCommand": "Dev Spaces: Restart Workspace from Local Devfile"
 	}
 }


### PR DESCRIPTION
`Restart Workspace from Local Devfile` action was added in the upstream, see https://github.com/che-incubator/che-code/pull/185.
The current PR provides `Dev Spaces` label for the `Restart Workspace from Local Devfile` action.