### PR TITLE
Provide Dev Spaces label for the 'Open OpenShift Console' action

### DIFF
--- a/devspaces-code/branding/product.json
+++ b/devspaces-code/branding/product.json
@@ -21,6 +21,7 @@
 	"remoteIndicatorCommands": {
 		"openDocumentationCommand": "Dev Spaces: Open Documentation",
 		"openDashboardCommand": "Dev Spaces: Open Dashboard",
+		"openOpenShiftConsoleCommand": "Dev Spaces: Open OpenShift Console",
 		"stopWorkspaceCommand": "Dev Spaces: Stop Workspace",
 		"restartWorkspaceCommand": "Dev Spaces: Restart Workspace",
 		"restartWorkspaceFromLocalDevfileCommand": "Dev Spaces: Restart Workspace from Local Devfile"


### PR DESCRIPTION
`Open OpenShift Console` action is going to be added to the upstream, see https://github.com/che-incubator/che-code/pull/191.
The current PR provides `Dev Spaces` label for the `Open OpenShift Console` action.