### PR TITLE
Fix: CRW-4120 Removing command to delete 'native-keymap' module in sync script and enabling pulp content sets to resolve libsecret & libxkbfile as rpm

### DIFF
--- a/devspaces-code/build/dockerfiles/content_sets_pulp.repo
+++ b/devspaces-code/build/dockerfiles/content_sets_pulp.repo
@@ -1,0 +1,17 @@
+[rhel-8-for-appstream-rpms-pulp]
+name=rhel-8-appstream-rpms-pulp
+baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/appstream/os
+enabled=1
+gpgcheck=0
+ 
+[rhel-8-for-baseos-rpms-pulp]
+name=rhel-8-baseos-rpms-pulp
+baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/baseos/os
+enabled=1
+gpgcheck=0
+
+[rhel-8-for-codeready-builder-rpms-pulp]
+name=rhel-8-codeready-builder-rpms-pulp
+baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/codeready-builder/os
+enabled=1
+gpgcheck=0

--- a/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
+++ b/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
@@ -17,28 +17,16 @@ USER root
 ARG GITHUB_TOKEN=''
 ENV GITHUB_TOKEN=$GITHUB_TOKEN
 
+# Enable pulp content sets to resolve libsecret & libxkbfile as rpm
+COPY ./build/dockerfiles/content_sets_pulp.repo /etc/yum.repos.d/
+
 # Unset GITHUB_TOKEN environment variable if it is empty.
 # This is needed for some tools which use this variable and will fail with 401 Unauthorized error if it is invalid.
 # For example, vscode ripgrep downloading is an example of such case.
 RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi
 
-# Install libsecret-devel on s390x and ppc64le for keytar build (binary included in npm package for x86)
-RUN { if [[ $(uname -m) == "s390x" ]]; then LIBSECRET="\
-      https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-0.20.4-2.fc34.s390x.rpm \
-      https://rpmfind.net/linux/fedora-secondary/releases/34/Everything/s390x/os/Packages/l/libsecret-devel-0.20.4-2.fc34.s390x.rpm"; \
-    elif [[ $(uname -m) == "ppc64le" ]]; then LIBSECRET="\
-      libsecret \
-      https://rpmfind.net/linux/centos/8-stream/BaseOS/ppc64le/os/Packages/libsecret-devel-0.18.6-1.el8.ppc64le.rpm"; \
-    elif [[ $(uname -m) == "x86_64" ]]; then LIBSECRET="\
-      https://rpmfind.net/linux/centos/8-stream/BaseOS/x86_64/os/Packages/libsecret-devel-0.18.6-1.el8.x86_64.rpm \
-      libsecret"; \
-    elif [[ $(uname -m) == "aarch64" ]]; then LIBSECRET="\
-      https://rpmfind.net/linux/centos/8-stream/BaseOS/aarch64/os/Packages/libsecret-devel-0.18.6-1.el8.aarch64.rpm \
-      libsecret"; \
-    else \
-      LIBSECRET=""; echo "Warning: arch $(uname -m) not supported"; \
-    fi; } \
-    && yum install -y $LIBSECRET curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less libX11-devel libxkbcommon bash tar gzip rsync patch \
+RUN yum -y -q update \
+    && yum install -y libsecret-devel libsecret curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less libX11-devel libxkbfile-devel libxkbfile libxkbcommon bash tar gzip rsync patch \
     && yum -y clean all && rm -rf /var/cache/yum \
     && npm install -g yarn@1.22.17
 COPY code /checode-compilation

--- a/devspaces-code/build/scripts/sync.sh
+++ b/devspaces-code/build/scripts/sync.sh
@@ -86,8 +86,6 @@ sed_in_place() {
   fi
 }
 
-sed_in_place -r \ '/"native-keymap":*/d' "${TARGETDIR}"/code/package.json
-
 sed_in_place -r \
   `# Update DevSpaces version for Dockerfile` \
   -e "s/version=.*/version=\"$DS_VERSION\" \\\/" \


### PR DESCRIPTION
code_3.x build fails on x86_64, s390x and ppc64le due to the following 2 reasons:

1. Failed to find module '**native-keymap**'. There was a command in the script used for syncing with upstream project which deletes the 'native-keymap' module. The command has been removed from the sync script.

2. The build requires 2 packages (**libsecret** & **libxkbfile**) to be installed into the image. The RPMs are not available at the default ubi8 yum repositories. Therefore, pulp content sets is enabled to install libsecret & libxkbfile as rpm.