### PR TITLE
fix: update sync.sh to remove references to theia plugins

### DIFF
--- a/devspaces-devfileregistry/build/scripts/sync.sh
+++ b/devspaces-devfileregistry/build/scripts/sync.sh
@@ -174,7 +174,4 @@ replaceField()
 
 pushd "${TARGETDIR}" >/dev/null || exit 1
 
-# TODO transform che-theia references to DS theia references, including:
-# description, icon, attributes.version, attributes.title, attributes.repository
-
 popd >/dev/null || exit

--- a/devspaces-devfileregistry/tests/basic-test.yaml
+++ b/devspaces-devfileregistry/tests/basic-test.yaml
@@ -36,7 +36,7 @@
           shell: oc exec {{ pod_name.stdout }} -- ls -las /var/www/html/ /var/www/html/devfiles
           register: ls_cmd_run
         - name: Make sure devfile templates are generated
-          shell: oc exec {{ pod_name.stdout }} -- find /var/www/html/devfiles -name devworkspace-che-theia-latest.yaml | grep .
+          shell: oc exec {{ pod_name.stdout }} -- find /var/www/html/devfiles -name devworkspace-che-code-latest.yaml | grep .
           register: ls_cmd_run
         - debug:
             msg: "{{ ls_cmd_run.stdout }}"

--- a/devspaces-pluginregistry/Dockerfile
+++ b/devspaces-pluginregistry/Dockerfile
@@ -77,7 +77,7 @@ COPY /build/scripts/*.sh resources.tgz che-*.yaml /build/
 
 RUN chmod 755 /usr/local/bin/*.sh && \
     tar -xvf /build/resources.tgz -C /build/ && \
-    rm -rf /build/output/v3/che-theia-plugins.yaml /build/output/v3/che-editors.yaml /build/output/v3/che-plugins.yaml && \
+    rm -rf /build/output/v3/che-editors.yaml && \
     /build/list_referenced_images.sh /build/output/v3 --use-generated-content > /build/output/v3/external_images.txt && cat /build/output/v3/external_images.txt && \
     chmod -R g+rwX /build && \
     cp -r /build/output/v3 /var/www/html/

--- a/devspaces-pluginregistry/build/scripts/sync.sh
+++ b/devspaces-pluginregistry/build/scripts/sync.sh
@@ -93,11 +93,9 @@ rsync -azrlt --checksum "${SOURCEDIR%/*}/job-config.json" "${TARGETDIR}"/
 # ensure shell scripts are executable
 find "${TARGETDIR}"/ -name "*.sh" -exec chmod +x {} \;
 
-# CRW-1792 transform che-editors.yaml#L5 and che-plugins.yaml#L3 to refer to /latest
+# CRW-1792 transform che-editors.yaml to refer to /latest
 pushd "${TARGETDIR}" >/dev/null || exit 1
-for d in che-editors.yaml che-plugins.yaml; do 
-    sed -i ${d} -r -e "s|/nightly|/latest|" -e "s|/next|/latest|"
-done
+sed -i che-editors.yaml -r -e "s|/nightly|/latest|" -e "s|/next|/latest|"
 popd >/dev/null || exit
 
 # transform Dockerfile


### PR DESCRIPTION
Since che-theia-plugins.yaml an che-plugins.yaml don't exist anymore, update a sync script in the plugin registry