### PR TITLE
feat: Provide branding for the Welcome page subtitle

### DIFF
--- a/devspaces-code/branding/product.json
+++ b/devspaces-code/branding/product.json
@@ -1,6 +1,7 @@
 {
 	"nameShort": "VS Code - Open Source",
-	"nameLong": "Red Hat OpenShift Dev Spaces with VS Code for the Web",
+	"nameLong": "Red Hat OpenShift Dev Spaces",
+	"nameLongSubtitle": "with Microsoft Visual Studio Code - Open Source IDE",
 	"workbenchConfigFilePath": "workbench-config.json",
 	"codiconCssFilePath": "css/codicon.css",
 	"icons": {


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/CRW-4114
The upstream changes: https://github.com/che-incubator/che-code/pull/216

Tested in upstream:
<img width="1572" alt="image" src="https://user-images.githubusercontent.com/5676062/234276288-ba3d3251-d463-4c3e-8827-3d0b75ceda51.png">
