### PR TITLE
switch to https; re-enable Z & P

### DIFF
--- a/devspaces-code/build/dockerfiles/content_sets_pulp.repo
+++ b/devspaces-code/build/dockerfiles/content_sets_pulp.repo
@@ -1,17 +1,17 @@
 [rhel-8-for-appstream-rpms-pulp]
 name=rhel-8-appstream-rpms-pulp
-baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/appstream/os
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/appstream/os
 enabled=1
 gpgcheck=0
  
 [rhel-8-for-baseos-rpms-pulp]
 name=rhel-8-baseos-rpms-pulp
-baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/baseos/os
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/baseos/os
 enabled=1
 gpgcheck=0
 
 [rhel-8-for-codeready-builder-rpms-pulp]
 name=rhel-8-codeready-builder-rpms-pulp
-baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/codeready-builder/os
+baseurl=https://rhsm-pulp.corp.redhat.com/content/dist/rhel8/8/$basearch/codeready-builder/os
 enabled=1
 gpgcheck=0

--- a/devspaces-code/container.yaml
+++ b/devspaces-code/container.yaml
@@ -4,9 +4,8 @@ platforms:
 
   only:
     - x86_64
-    # disable to test a theory about arch-specific problem in https://issues.redhat.com/browse/CRW-4352
-    # - s390x
-    # - ppc64le
+    - s390x
+    - ppc64le
 
 compose:
   inherit: false


### PR DESCRIPTION
Change-Id:...

  ### What does this PR do?

switch to https; re-enable Z & P

Change-Id: I07b1d8afe4b1f345ba36f30966a94370b60bd7fe
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.