### PR TITLE
feat: Provide branding for the Welcome page

### DIFF
--- a/devspaces-code/branding/product.json
+++ b/devspaces-code/branding/product.json
@@ -1,7 +1,8 @@
 {
 	"nameShort": "VS Code - Open Source",
-	"nameLong": "Red Hat OpenShift Dev Spaces",
-	"nameLongSubtitle": "with Microsoft Visual Studio Code - Open Source IDE",
+	"nameLong": "Red Hat OpenShift Dev Spaces with Microsoft Visual Studio Code - Open Source IDE",
+	"welcomePageTitle": "Red Hat OpenShift Dev Spaces",
+	"welcomePageSubtitle": "with Microsoft Visual Studio Code - Open Source IDE",
 	"workbenchConfigFilePath": "workbench-config.json",
 	"codiconCssFilePath": "css/codicon.css",
 	"icons": {

--- a/devspaces-code/code/product.json
+++ b/devspaces-code/code/product.json
@@ -1,6 +1,6 @@
 {
 	"nameShort": "VS Code - Open Source",
-	"nameLong": "Red Hat OpenShift Dev Spaces",
+	"nameLong": "Red Hat OpenShift Dev Spaces with Microsoft Visual Studio Code - Open Source IDE",
 	"applicationName": "code-oss",
 	"dataFolderName": ".vscode-oss",
 	"win32MutexName": "che-code",
@@ -98,7 +98,6 @@
 		"serviceUrl": "https://open-vsx.org/vscode/gallery",
 		"itemUrl": "https://open-vsx.org/vscode/item"
 	},
-	"nameLongSubtitle": "with Microsoft Visual Studio Code - Open Source IDE",
 	"workbenchConfigFilePath": "workbench-config.json",
 	"codiconCssFilePath": "css/codicon.css",
 	"icons": {


### PR DESCRIPTION
Depends on:
- https://github.com/che-incubator/che-code/pull/219
- https://github.com/che-incubator/che-code/pull/223

Provides branding for the Welcome page
- value of the `welcomePageTitle` field is used as the `Welcome` page title
- value of the `welcomePageSubtitle` field is used as the `Welcome` page subtitle
- `nameLong` is still used for the `About` dialog and browser tab title

<img width="1064" alt="image" src="https://user-images.githubusercontent.com/5676062/236813549-d283286c-2090-445c-88d8-a85322f0ca80.png">

