### PR TITLE
chore: don't exclude IDEA in the dashboard editor's view

### DIFF
--- a/devspaces-dashboard/build/scripts/sync.sh
+++ b/devspaces-dashboard/build/scripts/sync.sh
@@ -148,13 +148,5 @@ while IFS= read -r -d '' d; do
   fi
 done <   <(find ${TARGETDIR}/ -name "*.json" -type f -print0)
 
-# https://issues.redhat.com/browse/CRW-3489 - remove che-theia from DS 3.6+
-# https://issues.redhat.com/browse/CRW-3485 - disable che-idea from DS 3.3+ as we don't want to show tech preview editors in the dashboard
-while IFS= read -r -d '' d; do
-  # see che-plugin-registry/che-editors.yaml, then for metadata.name=che-incubator/che-idea/next; exclude 'che-idea'
-  sed -i "${d}" -r -e "s@EXCLUDED_TARGET_EDITOR_NAMES = .+@EXCLUDED_TARGET_EDITOR_NAMES = ['che-idea', 'che-theia'];@"
-  echo "Updated EXCLUDED_TARGET_EDITOR_NAMES in ${d}"
-done <   <(find ${TARGETDIR}/ -name "SamplesListGallery.tsx" -type f -print0)
-
 # ensure shell scripts are executable
 find ${TARGETDIR}/ -name "*.sh" -exec chmod +x {} \;


### PR DESCRIPTION
Now we want to show che-idea editor in the User Dashboard, issue about that:

https://issues.redhat.com/browse/CRW-4139

Also we don't need to exclude che-theia editor since it was removed from the plugin registry and it doesn't exist at all