### PR TITLE
Temporary disable ghira job

### DIFF
--- a/crw-jenkins/jobs/DS_CI/Releng/ghira.groovy
+++ b/crw-jenkins/jobs/DS_CI/Releng/ghira.groovy
@@ -1,5 +1,5 @@
 pipelineJob("${FOLDER_PATH}/${ITEM_NAME}"){
-    disabled(false)
+    disabled(true)
     description('''Sync job between github issues and jira for docs team''')
 
     properties {


### PR DESCRIPTION
Temporary disable [ghira job](https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/DS_CI/job/Releng/job/ghira/) till https://github.com/eclipse/che/issues/22120 is fixed.