### PR TITLE
Arbitrary users in UDI should have $HOME write access

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -371,6 +371,9 @@ RUN \
     echo -n "php:    "; php -v; \
     echo "========"
 
+# A last pass to make sure that an arbitrary user can write in $HOME
+RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /home
+
 ENTRYPOINT [ "/entrypoint.sh" ]
 WORKDIR /projects
 CMD tail -f /dev/null


### PR DESCRIPTION
This is a fix for https://issues.redhat.com/browse/CRW-4517

I have tested using this [Dockerfile](https://gist.github.com/l0rd/c48f38c5220c64af5699a214fb7e64c3) that I have pushed it here: `quay.io/mloriedo/universal-developer-image:chgrp`

```Dockerfile
FROM registry.redhat.io/devspaces/udi-rhel8

USER root

# Set permissions on /home to allow arbitrary users to write
RUN mkdir -p /home/user && chgrp -R 0 /home && chmod -R g=u /home
```

I tested that I could run `npm install nodeshift` successfully:

```
$ npm install nodeshift
npm WARN deprecated har-validator@5.1.5: this library is no longer supported
npm WARN deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
npm WARN deprecated request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142

added 199 packages, and audited 200 packages in 11s

25 packages are looking for funding
  run `npm fund` for details

8 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
npm notice 
npm notice New major version of npm available! 8.19.3 -> 9.7.1
npm notice Changelog: https://github.com/npm/cli/releases/tag/v9.7.1
npm notice Run npm install -g npm@9.7.1 to update!
npm notice 
```