### PR TITLE
CRW-4801 Stop removing registry info from Dockerfiles

### DIFF
--- a/devspaces-devfileregistry/build/scripts/sync.sh
+++ b/devspaces-devfileregistry/build/scripts/sync.sh
@@ -99,9 +99,6 @@ find "${TARGETDIR}"/ -name "*.sh" -exec chmod +x {} \;
 # transform Dockerfile
 # shellcheck disable=SC1004
 sed "${TARGETDIR}/build/dockerfiles/Dockerfile" --regexp-extended \
-    `# Strip registry from image references` \
-    -e 's|FROM registry.access.redhat.com/|FROM |' \
-    -e 's|FROM registry.redhat.io/|FROM |' \
     `# CRW-2500 the folder is packed to resources.tgz` \
     -e 's|COPY ./resources /build/resources|# COPY ./resources /build/resources|' \
     `# CRW-2448 switch from ubi8 to rhel8 for OSBS` \

--- a/devspaces-idea/build/scripts/sync.sh
+++ b/devspaces-idea/build/scripts/sync.sh
@@ -86,8 +86,6 @@ sed_in_place() {
 sed_in_place -r \
   `# Update ubi8 image name` \
   -e "s#ubi8/ubi:#ubi8:#g" \
-  `# Remove registry so build works in Brew` \
-  -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/#FROM #g" \
   `# Remove unused Python packages (support for PyCharm not included in CRW)` \
   -e "/python2 python39 \\\\/d" \
   "${TARGETDIR}"/Dockerfile

--- a/devspaces-operator/build/scripts/sync.sh
+++ b/devspaces-operator/build/scripts/sync.sh
@@ -89,8 +89,6 @@ find "${TARGETDIR}"/ -name "*.sh" -exec chmod +x {} \;
 sed "${TARGETDIR}/build/dockerfiles/Dockerfile" --regexp-extended \
   `# Replace ubi8 with rhel8 version` \
   -e "s#ubi8/go-toolset#rhel8/go-toolset#g" \
-  `# Remove registry so build works in Brew` \
-  -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/#FROM #g" \
   > "${TARGETDIR}/Dockerfile"
 
 cat << EOT >> "${TARGETDIR}"/Dockerfile

--- a/devspaces-pluginregistry/build/scripts/sync.sh
+++ b/devspaces-pluginregistry/build/scripts/sync.sh
@@ -104,10 +104,6 @@ popd >/dev/null || exit
 # shellcheck disable=SC1004
 sed "${TARGETDIR}/build/dockerfiles/Dockerfile" --regexp-extended \
     -e 's|rhel8/postgresql-13:([0-9]+)(-[0-9.]+)|rhel8/postgresql-13:\1|g' \
-    `# Remove registry so build works in Brew` \
-    -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/#FROM #g" \
-    -e 's|FROM registry.access.redhat.com/|FROM |' \
-    -e 's|FROM registry.redhat.io/|FROM |' \
     `# Set arg options: disable BOOTSTRAP; update DS_BRANCH to correct value` \
     -e 's|ARG BOOTSTRAP=.*|ARG BOOTSTRAP=false|' \
     -e "s|ARG DS_BRANCH=.*|ARG DS_BRANCH=${DS_BRANCH}|" \

--- a/devspaces-server/build/scripts/sync.sh
+++ b/devspaces-server/build/scripts/sync.sh
@@ -167,6 +167,7 @@ generateFetchArtifactsPNCYaml
 
 # NOTE: upstream Dockerfile is in non-standard path (not build/dockerfiles/Dockerfile) because project has multiple container builds
 sed ${SOURCEDIR}/dockerfiles/che/Dockerfile -r \
+    -e 's@/home/user/eclipse-che@/home/user/devspaces@g' \
 	`# insert logic to unpack asset-*.tgz` \
     -e 's@ADD eclipse-che .+@# see fetch-artifacts-pnc.yaml\nCOPY artifacts/assembly-main.tar.gz /tmp/assembly-main.tar.gz\nRUN tar xzf /tmp/assembly-main.tar.gz --strip-components=1 -C /home/user/devspaces; rm -f /tmp/assembly-main.tar.gz\n@g' \
     -e 's@chmod g\\+w /home/user/cacerts@chmod 777 /home/user/cacerts@g' \

--- a/devspaces-server/build/scripts/sync.sh
+++ b/devspaces-server/build/scripts/sync.sh
@@ -167,10 +167,6 @@ generateFetchArtifactsPNCYaml
 
 # NOTE: upstream Dockerfile is in non-standard path (not build/dockerfiles/Dockerfile) because project has multiple container builds
 sed ${SOURCEDIR}/dockerfiles/che/Dockerfile -r \
-    `# Strip registry from image references` \
-    -e 's|FROM registry.access.redhat.com/|FROM |' \
-    -e 's|FROM registry.redhat.io/|FROM |' \
-    -e 's@/home/user/eclipse-che@/home/user/devspaces@g' \
 	`# insert logic to unpack asset-*.tgz` \
     -e 's@ADD eclipse-che .+@# see fetch-artifacts-pnc.yaml\nCOPY artifacts/assembly-main.tar.gz /tmp/assembly-main.tar.gz\nRUN tar xzf /tmp/assembly-main.tar.gz --strip-components=1 -C /home/user/devspaces; rm -f /tmp/assembly-main.tar.gz\n@g' \
     -e 's@chmod g\\+w /home/user/cacerts@chmod 777 /home/user/cacerts@g' \

--- a/devspaces-traefik/build/scripts/sync.sh
+++ b/devspaces-traefik/build/scripts/sync.sh
@@ -96,8 +96,6 @@ SOURCE_SHA=$(cd "${SOURCEDIR}"; git checkout "${TRAEFIK_VERSION}"; git rev-parse
 sed -r \
   `# Use the current SHA to build` \
   -e "s#ARG TRAEFIK_SHA=\".*\"#ARG TRAEFIK_SHA=\"${SOURCE_SHA}\"#g" \
-  `# Remove registry so build works in Brew` \
-  -e "s#FROM (registry.access.redhat.com|registry.redhat.io)/#FROM #g" \
   "${TARGETDIR}"/build/rhel.Dockerfile > "${TARGETDIR}"/Dockerfile
 
 cat << EOT >> "${TARGETDIR}"/Dockerfile


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-4801

Update sync.sh script to leave in the redhat registry info because brew now defaults to a registry that pulls in unreleased containers.