### PR TITLE
chore: Adapt dockerfile to moving VS Code to 18 Node.js

### DIFF
--- a/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
+++ b/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
@@ -8,8 +8,8 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-# https://registry.access.redhat.com/ubi8/nodejs-16
-FROM registry.access.redhat.com/ubi8/nodejs-16:1-118 as builder
+# https://registry.access.redhat.com/ubi8/nodejs-18
+FROM registry.access.redhat.com/ubi8/nodejs-18:1-60 as builder
 
 USER root
 
@@ -26,7 +26,7 @@ COPY ./build/dockerfiles/content_sets_pulp.repo /etc/yum.repos.d/
 RUN if [ -z $GITHUB_TOKEN ]; then unset GITHUB_TOKEN; fi
 
 RUN yum -y -q update \
-    && yum install -y libsecret-devel libsecret curl make cmake gcc gcc-c++ python2 git git-core-doc openssh less libX11-devel libxkbfile-devel libxkbfile libxkbcommon bash tar gzip rsync patch \
+    && yum install -y libsecret-devel libsecret curl make cmake gcc gcc-c++ python3.9 git git-core-doc openssh less libX11-devel libxkbfile-devel libxkbfile libxkbcommon bash tar gzip rsync patch \
     && yum -y clean all && rm -rf /var/cache/yum \
     && npm install -g yarn@1.22.17
 


### PR DESCRIPTION
**Depends on**: https://github.com/che-incubator/che-code/pull/265

Recently VS Code migrated to 18 Node.js.
Issue: https://github.com/eclipse/che/issues/22426
Upstream changes: https://github.com/che-incubator/che-code/pull/265/commits/494760c2ace1f0f06b975b9516f50bd41c7a70e7
