### PR TITLE
chore: CRW-4923 drop support for OCP 4.10 as...

### DIFF
--- a/devspaces-operator-bundle/Dockerfile
+++ b/devspaces-operator-bundle/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 Red Hat, Inc.
+# Copyright (c) 2020-2023 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -21,6 +21,9 @@ ENV SUMMARY="Red Hat OpenShift Dev Spaces operator-bundle container" \
     DESCRIPTION="Red Hat OpenShift Dev Spaces operator-bundle container" \
     PRODNAME="devspaces" \
     COMPNAME="operator-bundle"
+# https://access.redhat.com/support/policy/updates/openshift#dates
+# support for 4.12 ends on January 17, 2025
+# support for 4.11 ends on February 10, 2024
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \
       operators.operatorframework.io.bundle.manifests.v1=manifests/ \
       operators.operatorframework.io.bundle.metadata.v1=metadata/ \
@@ -28,7 +31,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \
       operators.operatorframework.io.bundle.channels.v1=stable \
       operators.operatorframework.io.bundle.channel.default.v1=stable \
       com.redhat.delivery.operator.bundle="true" \
-      com.redhat.openshift.versions="v4.10" \
+      com.redhat.openshift.versions="v4.11" \
       com.redhat.delivery.backport=false \
       summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/devspaces-operator-bundle/build/scripts/sync.sh
+++ b/devspaces-operator-bundle/build/scripts/sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2021-22 Red Hat, Inc.
+# Copyright (c) 2021-23 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -157,7 +157,7 @@ find "${TARGETDIR}"/ -name "*.sh" -exec chmod +x {} \;
 
 # create dockerfile
 cat << EOT > "${TARGETDIR}"/Dockerfile
-# Copyright (c) 2020-2021 Red Hat, Inc.
+# Copyright (c) 2020-$(date +%Y) Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -180,6 +180,9 @@ ENV SUMMARY="Red Hat OpenShift Dev Spaces ${MIDSTM_NAME} container" \\
     DESCRIPTION="Red Hat OpenShift Dev Spaces ${MIDSTM_NAME} container" \\
     PRODNAME="devspaces" \\
     COMPNAME="${MIDSTM_NAME}"
+# https://access.redhat.com/support/policy/updates/openshift#dates
+# support for 4.12 ends on January 17, 2025
+# support for 4.11 ends on February 10, 2024
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \\
       operators.operatorframework.io.bundle.manifests.v1=manifests/ \\
       operators.operatorframework.io.bundle.metadata.v1=metadata/ \\
@@ -187,7 +190,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \\
       operators.operatorframework.io.bundle.channels.v1=stable \\
       operators.operatorframework.io.bundle.channel.default.v1=stable \\
       com.redhat.delivery.operator.bundle="true" \\
-      com.redhat.openshift.versions="v4.10" \\
+      com.redhat.openshift.versions="v4.11" \\
       com.redhat.delivery.backport=false \\
       summary="\$SUMMARY" \\
       description="\$DESCRIPTION" \\


### PR DESCRIPTION
### What does this PR do?

chore: CRW-4923 drop support for OCP 4.10 as it's now EOL

Change-Id: Ied505fddae108ba2a468fd3023e75cd43b96333e
Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.