### PR TITLE
chore: try installing node-gyp explicitly...

### DIFF
--- a/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
+++ b/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
@@ -47,7 +47,7 @@ RUN git init .
 RUN yarn config set network-timeout 600000 -g
 
 # Install node-gyp, then yarn dependencies (force update to yarn.lock)
-RUN yarn add -W -D node-gyp; yarn install --force
+RUN yarn global add -W -D node-gyp; yarn install --force
 
 RUN echo "$(ulimit -a)"
 

--- a/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
+++ b/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
@@ -46,8 +46,9 @@ RUN git init .
 # change network timeout (slow using multi-arch build)
 RUN yarn config set network-timeout 600000 -g
 
-# Grab dependencies (and force to rebuild them)
-RUN yarn install --force
+# Install node-gyp, then yarn dependencies (force update to yarn.lock)
+RUN yarn add -W -D node-gyp 2> >(grep -v warning 1>&2); \
+    yarn install --force    2> >(grep -v warning 1>&2)
 
 RUN echo "$(ulimit -a)"
 

--- a/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
+++ b/devspaces-code/build/dockerfiles/libc-content-provider.Dockerfile
@@ -47,8 +47,7 @@ RUN git init .
 RUN yarn config set network-timeout 600000 -g
 
 # Install node-gyp, then yarn dependencies (force update to yarn.lock)
-RUN yarn add -W -D node-gyp 2> >(grep -v warning 1>&2); \
-    yarn install --force    2> >(grep -v warning 1>&2)
+RUN yarn add -W -D node-gyp; yarn install --force
 
 RUN echo "$(ulimit -a)"
 


### PR DESCRIPTION
### What does this PR do?

chore: try installing node-gyp explicitly before yarn install + lock regen (CRW-4961)

Signed-off-by: Nick Boldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.