### PR TITLE
Update to newest builders (and go builder to go 1.20) for CVE fixes

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -11,7 +11,7 @@
 # use rhel8/ for Brew, not ubi8/
 # can pin to specific tag filter using rhel8/go-toolset#^1.17
 # https://registry.access.redhat.com/rhel8/go-toolset
-FROM rhel8/go-toolset:1.19.13-2 as go-builder
+FROM rhel8/go-toolset:1.20.10-3 as go-builder
 
 USER root
 
@@ -56,8 +56,7 @@ RUN \
     # END Kamel
 
 # https://registry.access.redhat.com/ubi8-minimal
-FROM ubi8-minimal:8.8-1072
-
+FROM ubi8-minimal:8.9-1029
 USER root
 
 ENV \


### PR DESCRIPTION
In my ongoing effort to fix the CVEs we have to manually fix, I have updated UDI to run on a go 1.20 image, and updated UBI8 to latest.

https://issues.redhat.com/browse/CRW-4846
https://issues.redhat.com/browse/CRW-4374
https://issues.redhat.com/browse/CRW-4655
https://issues.redhat.com/browse/CRW-4595
