### PR TITLE
fix: fixes for Cachito built-in sync

### DIFF
--- a/devspaces-code/build/scripts/sync-builtins.sh
+++ b/devspaces-code/build/scripts/sync-builtins.sh
@@ -125,7 +125,7 @@ addRipGrepLibrary() {
 
 addRipGrepToYaml() {
   #fetch post-install script for vscode ripgrep extension, in which we find the required version of ripgrep
-  VSCODE_RIPGREP_VERSION=$(cat ${TARGETDIR}/code/package.json | jq -r '.dependencies."@vscode/ripgrep"' | tr -d ^ )
+  VSCODE_RIPGREP_VERSION=$(yarn list --frozen-lockfile --pattern vscode/ripgrep --depth=0 --flat | grep -o -E @vscode/ripgrep@\\S* | cut -d '@' -f 3)
   # cache directory in brew.Dockerfile must be updated according to this version
   sed_in_place "s|COPY artifacts/ripgrep-*.tar.gz /tmp/vscode-ripgrep-cache-.*|\1${VSCODE_RIPGREP_VERSION}/|" ${TARGETDIR}/build/dockerfiles/brew.Dockerfile
   POST_INSTALL_SCRIPT=$(curl -sSL https://raw.githubusercontent.com/microsoft/vscode-ripgrep/v${VSCODE_RIPGREP_VERSION}/lib/postinstall.js)


### PR DESCRIPTION
- fix initialization of script dir variables (would fail on non-3-x branch execution otherwise
- read vscode-ripgrep version straight from yarn.lock, instead of package.json (don't want to deal with possible ranges in package.json)
- edit script output