### PR TITLE
chore: remove support for OCP 4.11 as its EOL soon CRW-5397

### DIFF
--- a/devspaces-operator-bundle/Dockerfile
+++ b/devspaces-operator-bundle/Dockerfile
@@ -22,8 +22,8 @@ ENV SUMMARY="Red Hat OpenShift Dev Spaces operator-bundle container" \
     PRODNAME="devspaces" \
     COMPNAME="operator-bundle"
 # https://access.redhat.com/support/policy/updates/openshift#dates
+# support for 4.13 ends on November 17, 2024
 # support for 4.12 ends on January 17, 2025
-# support for 4.11 ends on February 10, 2024
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \
       operators.operatorframework.io.bundle.manifests.v1=manifests/ \
       operators.operatorframework.io.bundle.metadata.v1=metadata/ \
@@ -31,7 +31,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \
       operators.operatorframework.io.bundle.channels.v1=stable \
       operators.operatorframework.io.bundle.channel.default.v1=stable \
       com.redhat.delivery.operator.bundle="true" \
-      com.redhat.openshift.versions="v4.11" \
+      com.redhat.openshift.versions="v4.12" \
       com.redhat.delivery.backport=false \
       summary="$SUMMARY" \
       description="$DESCRIPTION" \

--- a/devspaces-operator-bundle/build/scripts/sync.sh
+++ b/devspaces-operator-bundle/build/scripts/sync.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2021-23 Red Hat, Inc.
+# Copyright (c) 2021-24 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -181,8 +181,8 @@ ENV SUMMARY="Red Hat OpenShift Dev Spaces ${MIDSTM_NAME} container" \\
     PRODNAME="devspaces" \\
     COMPNAME="${MIDSTM_NAME}"
 # https://access.redhat.com/support/policy/updates/openshift#dates
+# support for 4.13 ends on November 17, 2024
 # support for 4.12 ends on January 17, 2025
-# support for 4.11 ends on February 10, 2024
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \\
       operators.operatorframework.io.bundle.manifests.v1=manifests/ \\
       operators.operatorframework.io.bundle.metadata.v1=metadata/ \\
@@ -190,7 +190,7 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1 \\
       operators.operatorframework.io.bundle.channels.v1=stable \\
       operators.operatorframework.io.bundle.channel.default.v1=stable \\
       com.redhat.delivery.operator.bundle="true" \\
-      com.redhat.openshift.versions="v4.11" \\
+      com.redhat.openshift.versions="v4.12" \\
       com.redhat.delivery.backport=false \\
       summary="\$SUMMARY" \\
       description="\$DESCRIPTION" \\


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-5397