### PR TITLE
fix: get correct tag of openvsx-server repo

### DIFF
--- a/devspaces-pluginregistry/get-sources.sh
+++ b/devspaces-pluginregistry/get-sources.sh
@@ -134,7 +134,7 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
     # save current branch name to the temporary file, it will be used in the openvsx-builder.Dockerfile build
     echo "$SCRIPT_BRANCH" > current_branch
     
-	# load job-config.json file
+    # load job-config.json file
     base_dir=$(cd "$(dirname "$0")"; pwd)
     jobconfigjson="${base_dir}/job-config.json"
     echo "Load ${jobconfigjson}"

--- a/devspaces-pluginregistry/get-sources.sh
+++ b/devspaces-pluginregistry/get-sources.sh
@@ -133,8 +133,19 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
     
     # save current branch name to the temporary file, it will be used in the openvsx-builder.Dockerfile build
     echo "$SCRIPT_BRANCH" > current_branch
-	# build 2 new tarballs
-	buildTarball "/openvsx-server.tar.gz" "che-openvsx" "build/dockerfiles/openvsx-builder.Dockerfile" "--target builder"
+    
+	# load job-config.json file
+    base_dir=$(cd "$(dirname "$0")"; pwd)
+    jobconfigjson="${base_dir}/job-config.json"
+    echo "Load ${jobconfigjson}"
+    # get the tag of che-openvsx from job-config.json
+    REGISTRY_VERSION=$(jq -r '.Version' "${jobconfigjson}");
+    echo "REGISTRY_VERSION ${REGISTRY_VERSION}"
+    CHE_OPENVSX_TAG=$(jq -r --arg REGISTRY_VERSION "${REGISTRY_VERSION}" '.Other["CHE_OPENVSX_TAG"][$REGISTRY_VERSION]' "${jobconfigjson}");
+    echo "CHE_OPENVSX_TAG ${CHE_OPENVSX_TAG}"
+
+    # build 2 new tarballs
+    buildTarball "/openvsx-server.tar.gz" "che-openvsx" "build/dockerfiles/openvsx-builder.Dockerfile" "--target builder --build-arg CHE_OPENVSX_TAG=${CHE_OPENVSX_TAG}"
 	buildTarball "opt/app-root/src/ovsx.tar.gz" "che-ovsx" "build/dockerfiles/ovsx-installer.Dockerfile" "--target builder"
 	# remove temporary file
 	rm current_branch 

--- a/devspaces-pluginregistry/get-sources.sh
+++ b/devspaces-pluginregistry/get-sources.sh
@@ -127,25 +127,25 @@ if [[ ${PULL_ASSETS} -eq 1 ]]; then
 	TARGZs="${TARGZs} resources.tgz"
 
 	SCRIPT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)"
-    if [[ $SCRIPT_BRANCH != "devspaces-3."*"-rhel-8" ]]; then
-        SCRIPT_BRANCH="devspaces-3-rhel-8"
-    fi
-    
-    # save current branch name to the temporary file, it will be used in the openvsx-builder.Dockerfile build
-    echo "$SCRIPT_BRANCH" > current_branch
-    
-    # load job-config.json file
-    base_dir=$(cd "$(dirname "$0")"; pwd)
-    jobconfigjson="${base_dir}/job-config.json"
-    echo "Load ${jobconfigjson}"
-    # get the tag of che-openvsx from job-config.json
-    REGISTRY_VERSION=$(jq -r '.Version' "${jobconfigjson}");
-    echo "REGISTRY_VERSION ${REGISTRY_VERSION}"
-    CHE_OPENVSX_TAG=$(jq -r --arg REGISTRY_VERSION "${REGISTRY_VERSION}" '.Other["CHE_OPENVSX_TAG"][$REGISTRY_VERSION]' "${jobconfigjson}");
-    echo "CHE_OPENVSX_TAG ${CHE_OPENVSX_TAG}"
+	if [[ $SCRIPT_BRANCH != "devspaces-3."*"-rhel-8" ]]; then
+		SCRIPT_BRANCH="devspaces-3-rhel-8"
+	fi
 
-    # build 2 new tarballs
-    buildTarball "/openvsx-server.tar.gz" "che-openvsx" "build/dockerfiles/openvsx-builder.Dockerfile" "--target builder --build-arg CHE_OPENVSX_TAG=${CHE_OPENVSX_TAG}"
+	# save current branch name to the temporary file, it will be used in the openvsx-builder.Dockerfile build
+	echo "$SCRIPT_BRANCH" > current_branch
+
+	# load job-config.json file
+	base_dir=$(cd "$(dirname "$0")"; pwd)
+	jobconfigjson="${base_dir}/job-config.json"
+	echo "Load ${jobconfigjson}"
+	# get the tag of che-openvsx from job-config.json
+	REGISTRY_VERSION=$(jq -r '.Version' "${jobconfigjson}");
+	echo "REGISTRY_VERSION ${REGISTRY_VERSION}"
+	CHE_OPENVSX_TAG=$(jq -r --arg REGISTRY_VERSION "${REGISTRY_VERSION}" '.Other["CHE_OPENVSX_TAG"][$REGISTRY_VERSION]' "${jobconfigjson}");
+	echo "CHE_OPENVSX_TAG ${CHE_OPENVSX_TAG}"
+
+	# build 2 new tarballs
+	buildTarball "/openvsx-server.tar.gz" "che-openvsx" "build/dockerfiles/openvsx-builder.Dockerfile" "--target builder --build-arg CHE_OPENVSX_TAG=${CHE_OPENVSX_TAG}"
 	buildTarball "opt/app-root/src/ovsx.tar.gz" "che-ovsx" "build/dockerfiles/ovsx-installer.Dockerfile" "--target builder"
 	# remove temporary file
 	rm current_branch 


### PR DESCRIPTION
Get tag of che-openvsx repository during the build to pull correct version

Related issue: https://issues.redhat.com/browse/CRW-5454