### PR TITLE
feat:install OS pipelines CLI

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -167,7 +167,10 @@ RUN \
         # http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/rhocp/4.12/os/Packages/o/openshift-clients-4.12.0-202312111251.p0.g6580ee0.assembly.stream.el8.x86_64.rpm
         # http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/s390x/rhocp/4.12/os/Packages/o/openshift-clients-4.12.0-202312111251.p0.g6580ee0.assembly.stream.el8.s390x.rpm
         # http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/rhocp/4.12/os/Packages/o/openshift-clients-4.12.0-202312111251.p0.g6580ee0.assembly.stream.el8.ppc64le.rpm
-        odo-3.9.0-1.el8 helm-3.10.1-2.el8 openshift-clients-4.12.0-202312111251.p0.g6580ee0.assembly.stream.el8 \
+        # http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/pipelines/1.13/os/Packages/o/openshift-pipelines-client-1.13.0-11230.el8.x86_64.rpm
+        # http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/s390x/pipelines/1.13/os/Packages/o/openshift-pipelines-client-1.13.0-11230.el8.s390x.rpm
+        # http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/ppc64le/pipelines/1.13/os/Packages/o/openshift-pipelines-client-1.13.0-11230.el8.ppc64le.rpm
+        odo-3.9.0-1.el8 helm-3.10.1-2.el8 openshift-clients-4.12.0-202312111251.p0.g6580ee0.assembly.stream.el8 openshift-pipelines-client-1.13.0-11230.el8 \
     && \
     dnf -y -q reinstall shadow-utils && \
     # fetch CVE updates (can exclude rpms to prevent update, eg., --exclude=odo)
@@ -412,6 +415,7 @@ RUN \
     echo -n "yq:     "; yq --version; \
     echo "========" && \
     echo -n "oc:      "; oc version; \
+    echo -n "tkn:     "; tkn version; \
     echo -n "odo:     "; odo version; \
     echo -n "helm:    "; helm version --short --client; \
     echo -n "kubectl: "; kubectl version --short --client=true; \

--- a/devspaces-udi/content_sets.repo
+++ b/devspaces-udi/content_sets.repo
@@ -16,6 +16,12 @@ baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/$basearch/oc
 enabled=1
 gpgcheck=0
 
+[pipelines-1.13-for-rhel-8-rpms]
+name=pipelines-1.13-for-rhel-8-rpms
+baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/$basearch/pipelines/1.13/os/
+enabled=1
+gpgcheck=0
+
 [rhocp-4.12-for-rhel-8-rpms]
 name=rhocp-4.12-for-rhel-8-rpms
 baseurl=http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/$basearch/rhocp/4.12/os/

--- a/devspaces-udi/content_sets.yml
+++ b/devspaces-udi/content_sets.yml
@@ -14,16 +14,19 @@ x86_64:
 - rhel-8-for-x86_64-appstream-rpms
 - ocp-tools-4.12-for-rhel-8-x86_64-rpms
 - rhocp-4.12-for-rhel-8-x86_64-rpms
+- pipelines-1.13-for-rhel-8-x86_64-rpms
 - codeready-builder-for-rhel-8-x86_64-rpms
 s390x:
 - rhel-8-for-s390x-baseos-rpms
 - rhel-8-for-s390x-appstream-rpms
 - ocp-tools-4.12-for-rhel-8-s390x-rpms
 - rhocp-4.12-for-rhel-8-s390x-rpms
+- pipelines-1.13-for-rhel-8-s390x-rpms
 - codeready-builder-for-rhel-8-s390x-rpms
 ppc64le:
 - rhel-8-for-ppc64le-baseos-rpms
 - rhel-8-for-ppc64le-appstream-rpms
 - ocp-tools-4.12-for-rhel-8-ppc64le-rpms
 - rhocp-4.12-for-rhel-8-ppc64le-rpms
+- pipelines-1.13-for-rhel-8-ppc64le-rpms
 - codeready-builder-for-rhel-8-ppc64le-rpms


### PR DESCRIPTION
Integrates OpenShift Pipelines CLI (tkn) into Universal Developer Image

Related issue: https://issues.redhat.com/browse/CRW-3570

![screenshot-devspaces apps ci-ln-q5ybt3b-76ef8 origin-ci-int-aws dev rhcloud com-2024 01 18-14_35_38](https://github.com/redhat-developer/devspaces-images/assets/1271546/5cff2b77-8dfb-4d73-a075-cbca6aed17ef)

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 18-16_36_36](https://github.com/redhat-developer/devspaces-images/assets/1271546/fb22878a-67f4-4598-984b-605246f3198c)


Could be tested with **registry-proxy.engineering.redhat.com/rh-osbs/devspaces-udi-rhel8:devspaces-3-rhel-8-containers-candidate-96888-20240117160501**