### PR TITLE
CRW-6054 Update Configbump to use rhel-els 9.2

### DIFF
--- a/devspaces-configbump/build/dockerfiles/rhel.Dockerfile
+++ b/devspaces-configbump/build/dockerfiles/rhel.Dockerfile
@@ -12,7 +12,7 @@
 # see also brew.Dockerfile
 
 # https://registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12-5 as builder
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222 as builder
 USER 0
 ENV GOPATH=/go/ \
     CGO_ENABLED=1
@@ -21,7 +21,8 @@ WORKDIR /app
 COPY . ./
 
 #hadolint ignore=SC3010
-RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
+RUN dnf -y install golang && \
+    export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH="amd64"; elif [[ ${ARCH} == "aarch64" ]]; then export ARCH="arm64"; fi && \
     go mod download && go mod verify && \
     go test -v  ./... && \
     # to test FIPS compliance, run https://github.com/openshift/check-payload#scan-a-container-or-operator-image against a built image
@@ -30,13 +31,13 @@ RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH=
     chmod 755 /usr/local/bin/configbump
 
 # https://registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.9-1161 as runtime
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222 as runtime
 #hadolint ignore=DL4006
-RUN microdnf -y install shadow-utils && \
+RUN dnf -y install shadow-utils && \
     adduser appuser && \
-    microdnf -y remove shadow-utils && \
-    microdnf -y update || true && \
-    microdnf -y clean all && rm -rf /var/cache/yum && \
+    dnf -y remove shadow-utils && \
+    dnf -y update || true && \
+    dnf -y clean all && rm -rf /var/cache/yum && \
     echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 
 USER appuser

--- a/devspaces-configbump/build/scripts/sync.sh
+++ b/devspaces-configbump/build/scripts/sync.sh
@@ -73,24 +73,18 @@ rm -f /tmp/rsync-excludes
 # ensure shell scripts are executable
 find "${TARGETDIR}"/ -name "*.sh" -exec chmod +x {} \;
 
-# add brew metadata to downstream build/dockerfiles/brew.Dockerfile
-cat << EOT >> "${TARGETDIR}"/build/dockerfiles/brew.Dockerfile
+sed_in_place() {
+    SHORT_UNAME=$(uname -s)
+  if [ "$(uname)" == "Darwin" ]; then
+    sed -i '' "$@"
+  elif [ "${SHORT_UNAME:0:5}" == "Linux" ]; then
+    sed -i "$@"
+  fi
+}
 
-ENV SUMMARY="Red Hat OpenShift Dev Spaces ${MIDSTM_NAME} container" \\
-    DESCRIPTION="Red Hat OpenShift Dev Spaces ${MIDSTM_NAME} container" \\
-    PRODNAME="devspaces" \\
-    COMPNAME="${MIDSTM_NAME}-rhel8"
-LABEL summary="\$SUMMARY" \\
-      description="\$DESCRIPTION" \\
-      io.k8s.description="\$DESCRIPTION" \\
-      io.k8s.display-name="\$DESCRIPTION" \\
-      io.openshift.tags="\$PRODNAME,\$COMPNAME" \\
-      com.redhat.component="\$PRODNAME-\$COMPNAME-container" \\
-      name="\$PRODNAME/\$COMPNAME" \\
-      version="${DS_VERSION}" \\
-      license="EPLv2" \\
-      maintainer="Nick Boldt <nboldt@redhat.com>" \\
-      io.openshift.expose-services="" \\
-      usage=""
-EOT
-echo "Converted Dockerfiles"
+sed_in_place -r \
+  `# Update DevSpaces version for Dockerfile` \
+  -e "s/version=.*/version=\"$DS_VERSION\" \\\/" \
+  "${TARGETDIR}"/build/dockerfiles/brew.Dockerfile
+
+echo "Converted Dockerfile"

--- a/devspaces-configbump/build/scripts/sync.sh
+++ b/devspaces-configbump/build/scripts/sync.sh
@@ -54,6 +54,8 @@ echo ".github/
 .travis
 .travis.yaml
 .gitattributes
+build/dockerfiles/brew.Dockerfile
+build/dockerfiles/rhel.Dockerfile
 build/scripts/
 tests/
 /container.yaml

--- a/devspaces-configbump/content_sets.yml
+++ b/devspaces-configbump/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-8-for-x86_64-baseos-rpms
-- rhel-8-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-rpms
+- rhel-9-for-x86_64-appstream-rpms
 s390x:
-- rhel-8-for-s390x-baseos-rpms
-- rhel-8-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-rpms
+- rhel-9-for-s390x-appstream-rpms
 ppc64le:
-- rhel-8-for-ppc64le-baseos-rpms
-- rhel-8-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-rpms
+- rhel-9-for-ppc64le-appstream-rpms
 

--- a/devspaces-configbump/content_sets.yml
+++ b/devspaces-configbump/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-9-for-x86_64-baseos-rpms
-- rhel-9-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
 s390x:
-- rhel-9-for-s390x-baseos-rpms
-- rhel-9-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
 ppc64le:
-- rhel-9-for-ppc64le-baseos-rpms
-- rhel-9-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
 


### PR DESCRIPTION
Update dockerfiles to use rhel-els and update sync to not overwrite them with upstream versions.
Updating content sets for rhel 9

https://issues.redhat.com/browse/CRW-6054
https://issues.redhat.com/browse/CRW-3185