### PR TITLE
CRW-6054 Update Machineexec to use rhel-els 9.2

### DIFF
--- a/devspaces-machineexec/build/dockerfiles/brew.Dockerfile
+++ b/devspaces-machineexec/build/dockerfiles/brew.Dockerfile
@@ -10,14 +10,15 @@
 #
 
 # https://registry.access.redhat.com/rhel8/go-toolset
-FROM rhel8/go-toolset:1.20.12-5 as builder
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222 as builder
 ENV GOPATH=/go/ \
     CGO_ENABLED=1
 USER root
 WORKDIR /che-machine-exec/
 COPY . .
 # to test FIPS compliance, run https://github.com/openshift/check-payload#scan-a-container-or-operator-image against a built image
-RUN adduser unprivilegeduser && \
+RUN dnf -y install golang && \
+    adduser unprivilegeduser && \
     GOOS=linux go build -mod=vendor -a -ldflags '-w -s' -a -installsuffix cgo -o che-machine-exec . && \
     mkdir -p /rootfs/tmp /rootfs/etc /rootfs/go/bin && \
     # In the `scratch` you can't use Dockerfile#RUN, because there is no shell and no standard commands (mkdir and so on).
@@ -27,9 +28,9 @@ RUN adduser unprivilegeduser && \
     cp -rf /che-machine-exec/che-machine-exec /rootfs/go/bin
 
 # https://registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.9-1161 as runtime
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222 as runtime
 COPY --from=builder /rootfs /
-RUN microdnf install -y openssl; microdnf clean -y all
+RUN dnf install -y openssl; dnf clean -y all
 USER unprivilegeduser
 ENTRYPOINT ["/go/bin/che-machine-exec"]
 

--- a/devspaces-machineexec/build/scripts/sync.sh
+++ b/devspaces-machineexec/build/scripts/sync.sh
@@ -70,23 +70,18 @@ rm -f /tmp/rsync-excludes
 # ensure shell scripts are executable
 find "${TARGETDIR}"/ -name "*.sh" -exec chmod +x {} \;
 
-cat << EOT >> "${TARGETDIR}"/build/dockerfiles/brew.Dockerfile
+sed_in_place() {
+    SHORT_UNAME=$(uname -s)
+  if [ "$(uname)" == "Darwin" ]; then
+    sed -i '' "$@"
+  elif [ "${SHORT_UNAME:0:5}" == "Linux" ]; then
+    sed -i "$@"
+  fi
+}
 
-ENV SUMMARY="Red Hat OpenShift Dev Spaces ${MIDSTM_NAME} container" \\
-    DESCRIPTION="Red Hat OpenShift Dev Spaces ${MIDSTM_NAME} container" \\
-    PRODNAME="devspaces" \\
-    COMPNAME="${MIDSTM_NAME}-rhel8"
-LABEL summary="\$SUMMARY" \\
-      description="\$DESCRIPTION" \\
-      io.k8s.description="\$DESCRIPTION" \\
-      io.k8s.display-name="\$DESCRIPTION" \\
-      io.openshift.tags="\$PRODNAME,\$COMPNAME" \\
-      com.redhat.component="\$PRODNAME-\$COMPNAME-container" \\
-      name="\$PRODNAME/\$COMPNAME" \\
-      version="${DS_VERSION}" \\
-      license="EPLv2" \\
-      maintainer="Anatolii Bazko <abazko@redhat.com>, Nick Boldt <nboldt@redhat.com>" \\
-      io.openshift.expose-services="" \\
-      usage=""
-EOT
+sed_in_place -r \
+  `# Update DevSpaces version for Dockerfile` \
+  -e "s/version=.*/version=\"$DS_VERSION\" \\\/" \
+  "${TARGETDIR}"/build/dockerfiles/brew.Dockerfile
+
 echo "Converted Dockerfile"

--- a/devspaces-machineexec/build/scripts/sync.sh
+++ b/devspaces-machineexec/build/scripts/sync.sh
@@ -50,6 +50,8 @@ echo ".github/
 .git/
 .gitattributes
 build/scripts/sync.sh
+build/dockerfiles/brew.Dockerfile
+build/dockerfiles/rhel.Dockerfile
 /container.yaml
 /content_sets.*
 /cvp.yml

--- a/devspaces-machineexec/content_sets.yml
+++ b/devspaces-machineexec/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-8-for-x86_64-baseos-rpms
-- rhel-8-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-rpms
+- rhel-9-for-x86_64-appstream-rpms
 s390x:
-- rhel-8-for-s390x-baseos-rpms
-- rhel-8-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-rpms
+- rhel-9-for-s390x-appstream-rpms
 ppc64le:
-- rhel-8-for-ppc64le-baseos-rpms
-- rhel-8-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-rpms
+- rhel-9-for-ppc64le-appstream-rpms
 

--- a/devspaces-machineexec/content_sets.yml
+++ b/devspaces-machineexec/content_sets.yml
@@ -12,12 +12,11 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-9-for-x86_64-baseos-rpms
-- rhel-9-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
 s390x:
-- rhel-9-for-s390x-baseos-rpms
-- rhel-9-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
 ppc64le:
-- rhel-9-for-ppc64le-baseos-rpms
-- rhel-9-for-ppc64le-appstream-rpms
-
+- rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2


### PR DESCRIPTION
Update dockerfiles to use rhel-els and update sync to not overwrite them with upstream versions.
Updating content sets for rhel 9

https://issues.redhat.com/browse/CRW-6054
https://issues.redhat.com/browse/CRW-3185
