### PR TITLE
CRW-6054 Update Server to use rhel-els 9.2

### DIFF
--- a/devspaces-server/Dockerfile
+++ b/devspaces-server/Dockerfile
@@ -10,13 +10,13 @@
 #
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.9-1161
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 USER root
 ENV CHE_HOME=/home/user/devspaces
 ENV JAVA_HOME=/usr/lib/jvm/jre
-RUN microdnf install java-17-openjdk-headless tar gzip shadow-utils findutils && \
-    microdnf update -y && \
-    microdnf -y clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages" && \
+RUN dnf -y install java-17-openjdk-headless tar gzip shadow-utils findutils && \
+    dnf update -y && \
+    dnf -y clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages" && \
     adduser -G root user && mkdir -p /home/user/devspaces
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/devspaces-server/build/dockerfiles/brew.Dockerfile
+++ b/devspaces-server/build/dockerfiles/brew.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2023 Red Hat, Inc.
+# Copyright (c) 2018-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/devspaces-server/content_sets.yml
+++ b/devspaces-server/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-8-for-x86_64-baseos-rpms
-- rhel-8-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-rpms
+- rhel-9-for-x86_64-appstream-rpms
 s390x:
-- rhel-8-for-s390x-baseos-rpms
-- rhel-8-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-rpms
+- rhel-9-for-s390x-appstream-rpms
 ppc64le:
-- rhel-8-for-ppc64le-baseos-rpms
-- rhel-8-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-rpms
+- rhel-9-for-ppc64le-appstream-rpms
 

--- a/devspaces-server/content_sets.yml
+++ b/devspaces-server/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-9-for-x86_64-baseos-rpms
-- rhel-9-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
 s390x:
-- rhel-9-for-s390x-baseos-rpms
-- rhel-9-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
 ppc64le:
-- rhel-9-for-ppc64le-baseos-rpms
-- rhel-9-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
 


### PR DESCRIPTION
Update dockerfiles to use rhel-els and update sync to not overwrite them with upstream versions.
Updating content sets for rhel 9

https://issues.redhat.com/browse/CRW-6054
https://issues.redhat.com/browse/CRW-3185
