### PR TITLE
CRW-6054 Update operator to use rhel-els 9.2

### DIFF
--- a/devspaces-operator/build/dockerfiles/Dockerfile
+++ b/devspaces-operator/build/dockerfiles/Dockerfile
@@ -10,7 +10,7 @@
 #
 
 # https://registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12-5 as builder
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222 as builder
 ENV GOPATH=/go/ \
     CGO_ENABLED=1
 ARG SKIP_TESTS="false"
@@ -20,6 +20,8 @@ USER root
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
 RUN source $REMOTE_SOURCES_DIR/devspaces-images-operator/cachito.env
 WORKDIR $REMOTE_SOURCES_DIR/devspaces-images-operator/app/devspaces-operator
+
+RUN dnf -y install golang
 
 RUN mkdir -p /tmp/devworkspace-operator/templates/ && \
     mv $REMOTE_SOURCES_DIR/DEV_WORKSPACE_CONTROLLER/app/deploy/deployment/* /tmp/devworkspace-operator/templates/
@@ -48,7 +50,7 @@ RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH=
     GOOS=linux GOARCH=${ARCH} GO111MODULE=on go build -mod=vendor -a -o che-operator main.go
 
 # https://registry.access.redhat.com/ubi8-minimal
-FROM ubi8-minimal:8.9-1161
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1222
 
 COPY --from=builder /tmp/devworkspace-operator/templates /tmp/devworkspace-operator/templates
 COPY --from=builder /tmp/header-rewrite-traefik-plugin /tmp/header-rewrite-traefik-plugin

--- a/devspaces-operator/content_sets.yml
+++ b/devspaces-operator/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-8-for-x86_64-baseos-rpms
-- rhel-8-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-rpms
+- rhel-9-for-x86_64-appstream-rpms
 s390x:
-- rhel-8-for-s390x-baseos-rpms
-- rhel-8-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-rpms
+- rhel-9-for-s390x-appstream-rpms
 ppc64le:
-- rhel-8-for-ppc64le-baseos-rpms
-- rhel-8-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-rpms
+- rhel-9-for-ppc64le-appstream-rpms
 

--- a/devspaces-operator/content_sets.yml
+++ b/devspaces-operator/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-9-for-x86_64-baseos-rpms
-- rhel-9-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
 s390x:
-- rhel-9-for-s390x-baseos-rpms
-- rhel-9-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
 ppc64le:
-- rhel-9-for-ppc64le-baseos-rpms
-- rhel-9-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
 


### PR DESCRIPTION
Update dockerfiles to use rhel-els and update sync to not overwrite them with upstream versions.
Updating content sets for rhel 9

https://issues.redhat.com/browse/CRW-6054
https://issues.redhat.com/browse/CRW-3185
