### PR TITLE
chore: remove ghcr.io/ansible/ansible-workspace-env-reference from EXTERNAL_IMAGES

### DIFF
--- a/devspaces-operator-bundle/build/scripts/insert-related-images-to-csv.sh
+++ b/devspaces-operator-bundle/build/scripts/insert-related-images-to-csv.sh
@@ -71,9 +71,9 @@ tmpdir=$(mktemp -d); mkdir -p $tmpdir; pushd $tmpdir >/dev/null
     fi
 
     # CRW-3177, CRW-3178 sort uniquely; replace quay refs with RHEC refs
-    # remove quay.io/devspaces/ansible-creator-ee from EXTERNAL_IMAGES CRW-4541
+    # remove ghcr.io/ansible/ansible-workspace-env-reference from EXTERNAL_IMAGES
     EXTERNAL_IMAGES=$(cat /tmp/quay.io-devspaces-{devfile,plugin}registry-rhel8-${DS_VERSION}*/var/www/html/*/external_images.txt | \
-      sed -r -e '/^quay\.io\/devspaces\/ansible-creator-ee/d' \
+      sed -r -e '/^ghcr\.io\/ansible\/ansible-workspace-env-reference/d' \
       -e "s#quay.io/devspaces/#registry.redhat.io/devspaces/#g" | sort -uV)
 
     # CRW-3432 fail if we don't get a list of images
@@ -130,7 +130,7 @@ sed -r -i $CSVFILE \
   -e "s@registry.access.redhat.com/ubi8/ubi-minimal@registry.redhat.io/ubi8/ubi-minimal@g" \
   `# CRW-1254 use ubi8/ubi-minimal for airgap mirroring` \
   -e "s@/ubi8-minimal@/ubi8/ubi-minimal@g" \
-  `# replace quay urls with RHEC urls except quay.io/devspaces/ansible-creator-ee` \
+  `# replace quay urls with RHEC urls` \
   -e "s|quay.io/devspaces/(.+)|registry.redhat.io/devspaces/\\1|g"
 
 # echo list of RELATED_IMAGE_ entries after adding them above


### PR DESCRIPTION
Ansible image was replaced in https://github.com/devspaces-samples/ansible-devspaces-demo/pull/28, we need to remove ghcr.io/ansible/ansible-workspace-env-reference from the list of external images

Related issue: https://issues.redhat.com/browse/CRW-6346
