### PR TITLE
Use docs.redhat.com in links to documentation

### DIFF
--- a/devspaces-dashboard/build/scripts/sync.sh
+++ b/devspaces-dashboard/build/scripts/sync.sh
@@ -133,7 +133,7 @@ SHA_DS=$(cd ${TARGETDIR}; git rev-parse --short=4 HEAD)
 echo "Using: DS_VERSION = $DS_VERSION (SHA_DS = $SHA_DS)"
 
 DS_SHAs="${DS_VERSION} @ ${SHA_DS} #${BUILD_NUMBER} :: Eclipse Che Dashboard ${VER_CHE} @ ${SHA_CHE}"
-DS_DOCS_BASEURL="https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/${DS_VERSION}"
+DS_DOCS_BASEURL="https://docs.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/${DS_VERSION}"
 sed -r \
     -e "s|@@devspaces.version@@|${DS_SHAs}|g" \
     -e "s#@@devspaces.docs.baseurl@@#${DS_DOCS_BASEURL}#g" \


### PR DESCRIPTION
Fix outdated links to the documentation in User Dashboard: https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/

Correct link is https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/

Affected sources:
- 3.x: https://raw.githubusercontent.com/redhat-developer/devspaces-images/devspaces-3-rhel-8/devspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json
3.15: https://raw.githubusercontent.com/redhat-developer/devspaces-images/devspaces-3.15-rhel-8/devspaces-dashboard/packages/dashboard-frontend/assets/branding/product.json

Closes https://issues.redhat.com/browse/CRW-6795