### PR TITLE
fix: update version of IntelliJ IDEA editor's definition

### DIFF
--- a/devspaces-operator/editors-definitions/che-idea.yaml
+++ b/devspaces-operator/editors-definitions/che-idea.yaml
@@ -8,7 +8,7 @@ metadata:
     - Tech-Preview
   attributes:
     publisher: che-incubator
-    version: 2022.1
+    version: latest
     title: Red Hat OpenShift Dev Spaces with JetBrains IntelliJ IDEA Community IDE
     repository: https://github.com/che-incubator/jetbrains-editor-images
     firstPublicationDate: '2022-01-11'


### PR DESCRIPTION
Fix version of IntelliJ IDEA editor's definition. It should be latest to correctly reference generated resources.

Related issue: https://issues.redhat.com/browse/CRW-6841