### PR TITLE
chore: install java 21 into UDI

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -80,6 +80,7 @@ ENV \
     LD_LIBRARY_PATH="/usr/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}" \
     CPATH="/usr/include${CPATH:+:${CPATH}}" \
     DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    JAVA_HOME_21=/usr/lib/jvm/java-21-openjdk \
     JAVA_HOME_17=/usr/lib/jvm/java-17-openjdk \
     JAVA_HOME_11=/usr/lib/jvm/java-11-openjdk \
     JAVA_HOME_8=/usr/lib/jvm/java-1.8.0-openjdk \
@@ -147,6 +148,7 @@ RUN \
         java-1.8.0-openjdk java-1.8.0-openjdk-devel java-1.8.0-openjdk-headless \
             java-11-openjdk java-11-openjdk-devel java-11-openjdk-src java-11-openjdk-headless \
             java-17-openjdk java-17-openjdk-devel java-17-openjdk-headless \
+            java-21-openjdk java-21-openjdk-devel java-21-openjdk-headless \
         nodejs npm nodejs-nodemon nss_wrapper \
         make cmake gcc gcc-c++ \
             llvm-toolset clang clang-libs clang-tools-extra git-clang-format gdb \
@@ -386,6 +388,8 @@ RUN \
     echo -n "Java 11:  "; /usr/lib/jvm/java-11-openjdk/bin/java -version; \
     echo "========" && \
     echo -n "Java 17:  "; /usr/lib/jvm/java-17-openjdk/bin/java -version; \
+    echo "========" && \
+    echo -n "Java 21:  "; /usr/lib/jvm/java-21-openjdk/bin/java -version; \
     echo "========" && \
     echo -n "mvn:    "; mvn -version; \
     echo "========" && \

--- a/devspaces-udi/etc/entrypoint.sh
+++ b/devspaces-udi/etc/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright (c) 2019-2022 Red Hat, Inc.
+# Copyright (c) 2019-2024 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -44,7 +44,8 @@ fi
 
 #############################################################################
 # use java 8 if USE_JAVA8 is set to 'true', 
-# use java 11 if USE_JAVA11 is set to 'true', 
+# use java 11 if USE_JAVA11 is set to 'true',
+# use java 21 if USE_JAVA21 is set to 'true', 
 # by default it is java 17
 #############################################################################
 rm -rf /home/tooling/.java/current
@@ -55,6 +56,9 @@ if [ "${USE_JAVA8}" == "true" ] && [ ! -z "${JAVA_HOME_8}" ]; then
 elif [ "${USE_JAVA11}" == "true" ] && [ ! -z "${JAVA_HOME_11}" ]; then
   ln -s "${JAVA_HOME_11}"/* /home/tooling/.java/current
   echo "Java environment set to ${JAVA_HOME_11}"
+elif [ "${USE_JAVA21}" == "true" ] && [ ! -z "${JAVA_HOME_21}" ]; then
+  ln -s "${JAVA_HOME_21}"/* /home/tooling/.java/current
+  echo "Java environment set to ${JAVA_HOME_21}"
 else
   ln -s "${JAVA_HOME_17}"/* /home/tooling/.java/current
   echo "Java environment set to ${JAVA_HOME_17}"


### PR DESCRIPTION
Add Java 21 into UDI:

![screenshot-nimbusweb me-2024 07 26-13_41_13](https://github.com/user-attachments/assets/7e36b0e7-b29b-4eac-b74f-88676fb5783b)

Java 17 is still a default one 

Built in: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=62917751
Resulted image: registry-proxy.engineering.redhat.com/rh-osbs/devspaces-udi-rhel8:devspaces-3-rhel-8-containers-candidate-87253-20240726082019

You can test it with this [factory link](https://devspaces.apps.sandbox-stage.gb17.p1.openshiftapps.com/dashboard/#/https://gist.githubusercontent.com/svor/e7eb774091c4569af1b427d6ef6e6a88/raw/25bcd94c691e124dd2f473d4db62a0dce1934509/java21.devfile)

**Related Issue:**
https://issues.redhat.com/browse/CRW-6855