### PR TITLE
Renew link to official documentation in sync.sh

### DIFF
--- a/devspaces-dashboard/build/scripts/sync.sh
+++ b/devspaces-dashboard/build/scripts/sync.sh
@@ -144,7 +144,7 @@ SHA_DS=$(cd ${TARGETDIR}; git rev-parse --short=4 HEAD)
 echo "Using: DS_VERSION = $DS_VERSION (SHA_DS = $SHA_DS)"
 
 DS_SHAs="${DS_VERSION} @ ${SHA_DS} #${BUILD_NUMBER} :: Eclipse Che Dashboard ${VER_CHE} @ ${SHA_CHE}"
-DS_DOCS_BASEURL="https://docs.redhat.com/documentation/en/red_hat_openshift_dev_spaces/${DS_VERSION}"
+DS_DOCS_BASEURL="https://docs.redhat.com/en/documentation/red_hat_openshift_dev_spaces/${DS_VERSION}"
 sed -r \
     -e "s|@@devspaces.version@@|${DS_SHAs}|g" \
     -e "s#@@devspaces.docs.baseurl@@#${DS_DOCS_BASEURL}#g" \


### PR DESCRIPTION
One more fix to have the link to the official documentation up to date.

![Screenshot from 2024-08-30 22-52-34](https://github.com/user-attachments/assets/9039270f-43d7-49ec-9d0f-042509fb4f51)
