### PR TITLE
Update Dashboard to use els image and fix build issue with yarn 3 update

### DIFF
--- a/devspaces-dashboard/build/dockerfiles/brew.Dockerfile
+++ b/devspaces-dashboard/build/dockerfiles/brew.Dockerfile
@@ -8,15 +8,16 @@
 # Contributors:
 #   Red Hat, Inc. - initial API and implementation
 
-# https://registry.access.redhat.com/ubi8/nodejs-18
-FROM ubi8/nodejs-18:1-122.1724231540 as builder
+# https://registry.access.redhat.com/rhel9-2-els/rhel
+FROM registry.redhat.io/rhel9-2-els/rhel:9.2-1327 as builder
 # hadolint ignore=DL3002
 USER 0
 RUN dnf -y -q update --exclude=unbound-libs 
 # https://docs.engineering.redhat.com/pages/viewpage.action?pageId=228017926#UpstreamSources%28Cachito,ContainerFirst%29-CachitoIntegrationforyarn
 # CRW-4644 Use RedHat nodejs headers to prevent node-gyp from trying to download them
 # hadolint ignore=DL3040,DL3059
-RUN dnf module install -y nodejs:18/development
+RUN dnf -y install g++ && \
+    dnf module install -y nodejs:18/development
 
 # cachito:yarn step 1: copy cachito sources where we can use them; source env vars; set working dir
 COPY $REMOTE_SOURCES $REMOTE_SOURCES_DIR
@@ -26,7 +27,7 @@ WORKDIR $REMOTE_SOURCES_DIR/devspaces-images-dashboard/app/devspaces-dashboard/
 
 # cachito:yarn step 2: workaround for yarn not being installed in an executable path
 COPY .yarn/releases $REMOTE_SOURCES_DIR/devspaces-images-dashboard/app/devspaces-dashboard/.yarn/releases/
-RUN ln -s "$REMOTE_SOURCES_DIR"/devspaces-images-dashboard/app/devspaces-dashboard/.yarn/releases/yarn-*.js /usr/local/bin/yarn
+RUN ln -s "$REMOTE_SOURCES_DIR"/devspaces-images-dashboard/app/devspaces-dashboard/.yarn/releases/yarn-*.cjs /usr/local/bin/yarn
 
 # cachito:yarn step 3: configure yarn & install deps
 # see https://source.redhat.com/groups/public/container-build-system/container_build_system_wiki/containers_from_source_multistage_builds_in_osbs#jive_content_id_Cachito_Integration_for_yarn

--- a/devspaces-dashboard/build/scripts/sync.sh
+++ b/devspaces-dashboard/build/scripts/sync.sh
@@ -64,6 +64,7 @@ packages/dashboard-frontend/assets/branding/
 packages/devfile-registry/air-gap/index.json
 samples/index.json
 build/scripts/
+build/dockerfiles/brew.Dockerfile
 container.yaml
 /content_sets.*
 /cvp.yml

--- a/devspaces-dashboard/content_sets.yml
+++ b/devspaces-dashboard/content_sets.yml
@@ -12,12 +12,12 @@
 # likely this will be x86_64 and ppc64le initially.
 ---
 x86_64:
-- rhel-8-for-x86_64-baseos-rpms
-- rhel-8-for-x86_64-appstream-rpms
+- rhel-9-for-x86_64-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-x86_64-appstream-eus-rpms__9_DOT_2
 s390x:
-- rhel-8-for-s390x-baseos-rpms
-- rhel-8-for-s390x-appstream-rpms
+- rhel-9-for-s390x-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-s390x-appstream-eus-rpms__9_DOT_2
 ppc64le:
-- rhel-8-for-ppc64le-baseos-rpms
-- rhel-8-for-ppc64le-appstream-rpms
+- rhel-9-for-ppc64le-baseos-eus-rpms__9_DOT_2
+- rhel-9-for-ppc64le-appstream-eus-rpms__9_DOT_2
 


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-6054
Updating dashboard to use rhel-els image. Installing g++ is necessary for build to run on s390x.

Fixing link to yarn since the new file has extension cjs and this wasn't caught in testing because of how cachito grabs files.