### PR TITLE
Fix name of yarn file in dashboard directory for Traefik and Code

### DIFF
--- a/devspaces-code/build/dockerfiles/brew.Dockerfile
+++ b/devspaces-code/build/dockerfiles/brew.Dockerfile
@@ -49,7 +49,7 @@ RUN source $REMOTE_SOURCES_DIR/devspaces-images-code/cachito.env; \
 
 # cachito:yarn step 2: workaround for yarn not being installed in an executable path
 # hadolint ignore=SC2086
-RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-code/app/devspaces-dashboard/.yarn/releases/yarn-*.js /usr/local/bin/yarn
+RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-code/app/devspaces-dashboard/.yarn/releases/yarn-*.cjs /usr/local/bin/yarn
 
 
 # VS Code depends on @vscode/ripgrep that downloads the required ripgrep binary from microsoft/ripgrep-prebuilt
@@ -267,7 +267,7 @@ RUN source $REMOTE_SOURCES_DIR/devspaces-images-code/cachito.env; \
 
 # cachito:yarn step 2: workaround for yarn not being installed in an executable path
 # hadolint ignore=SC2086
-RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-code/app/devspaces-dashboard/.yarn/releases/yarn-*.js /usr/local/bin/yarn
+RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-code/app/devspaces-dashboard/.yarn/releases/yarn-*.cjs /usr/local/bin/yarn
 
 
 # VS Code depends on @vscode/ripgrep that downloads the required ripgrep binary from microsoft/ripgrep-prebuilt

--- a/devspaces-traefik/Dockerfile
+++ b/devspaces-traefik/Dockerfile
@@ -8,7 +8,7 @@ RUN source $REMOTE_SOURCES_DIR/devspaces-images-traefik/cachito.env
 WORKDIR $REMOTE_SOURCES_DIR/devspaces-images-traefik/app/devspaces-traefik
 
 # cachito:yarn step 2: workaround for yarn not being installed in an executable path
-RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-traefik/app/devspaces-dashboard/.yarn/releases/yarn-*.js /usr/local/bin/yarn 
+RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-traefik/app/devspaces-dashboard/.yarn/releases/yarn-*.cjs /usr/local/bin/yarn 
 
 # CRW-3531 note: build fails when run with python39 and nodejs:16; so stick with python2 and nodejs:12
 ENV NODEJS_VERSION="12:8020020200326104117/development"

--- a/devspaces-traefik/build/rhel.Dockerfile
+++ b/devspaces-traefik/build/rhel.Dockerfile
@@ -8,7 +8,7 @@ RUN source $REMOTE_SOURCES_DIR/devspaces-images-traefik/cachito.env
 WORKDIR $REMOTE_SOURCES_DIR/devspaces-images-traefik/app/devspaces-traefik
 
 # cachito:yarn step 2: workaround for yarn not being installed in an executable path
-RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-traefik/app/devspaces-dashboard/.yarn/releases/yarn-*.js /usr/local/bin/yarn 
+RUN ln -s $REMOTE_SOURCES_DIR/devspaces-images-traefik/app/devspaces-dashboard/.yarn/releases/yarn-*.cjs /usr/local/bin/yarn 
 
 # CRW-3531 note: build fails when run with python39 and nodejs:16; so stick with python2 and nodejs:12
 ENV NODEJS_VERSION="12:8020020200326104117/development"


### PR DESCRIPTION
The extension on the yarn file changed from .js to .cjs so other builds dependent on that file need to be updated.