### PR TITLE
chore: upgrade mvn version to 3.8

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -142,7 +142,7 @@ RUN \
     dnf -y -q install 'dnf-command(config-manager)' && \
     dnf config-manager --set-disabled codeready-* && \
     dnf -y -q module reset container-tools maven nodejs php; \
-    dnf -y -q module install container-tools:rhel8 maven:3.6 nodejs:$NODEJS_VERSION php:$PHP_VERSION && \
+    dnf -y -q module install container-tools:rhel8 maven:3.8 nodejs:$NODEJS_VERSION php:$PHP_VERSION && \
     dnf -y -q install --setopt=tsflags=nodocs \
         golang \
         java-1.8.0-openjdk java-1.8.0-openjdk-devel java-1.8.0-openjdk-headless \


### PR DESCRIPTION
Related Issue: https://issues.redhat.com/browse/CRW-6270

Upgrades Maven to 3.8.5 version:
```
projects $ mvn --version
Apache Maven 3.8.5 (Red Hat 3.8.5-6)
Maven home: /usr/share/maven
Java version: 17.0.12, vendor: Red Hat, Inc., runtime: /usr/lib/jvm/java-17-openjdk-17.0.12.0.7-2.el8.x86_64
Default locale: en, platform encoding: UTF-8
OS name: "linux", version: "5.15.0-75-generic", arch: "amd64", family: "unix"
```

Built by: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=64380991

Resulted image: **registry-proxy.engineering.redhat.com/rh-osbs/devspaces-udi-rhel8:devspaces-3-rhel-8-containers-candidate-72176-20240920135412**