### PR TITLE
chore: update go-toolset to latest 1.21.13 image (#636)

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -11,7 +11,7 @@
 # use rhel8/ for Brew, not ubi8/
 # can pin to specific tag filter using rhel8/go-toolset#^1.17
 # https://registry.access.redhat.com/rhel8/go-toolset
-FROM rhel8/go-toolset:1.21.13-1 as go-builder
+FROM rhel8/go-toolset:1.21.13-1.1727172995 as go-builder
 
 USER root
 


### PR DESCRIPTION
Backport changes provided by https://github.com/redhat-developer/devspaces-images/pull/636