### PR TITLE
 Add upstream UBI/UDI bug fixes

### DIFF
--- a/devspaces-udi/Dockerfile
+++ b/devspaces-udi/Dockerfile
@@ -221,11 +221,7 @@ RUN \
     mkdir -p /var/lib/shared/overlay-images /var/lib/shared/overlay-layers; \
     touch /var/lib/shared/overlay-images/images.lock; \
     touch /var/lib/shared/overlay-layers/layers.lock && \
-    ## Rootless podman install #5: but use VFS since we were not able to make Fuse work yet...
-    # TODO switch this to fuse in OCP 4.12?
-    mkdir -p "${HOME}"/.config/containers && \
-    (echo '[storage]';echo 'driver = "vfs"') > "${HOME}"/.config/containers/storage.conf && \
-    ## Rootless podman install #6: rename podman to allow the execution of 'podman run' using
+    ## Rootless podman install #5: rename podman to allow the execution of 'podman run' using
     ##                             kubedock but 'podman build' using podman.orig
     mv /usr/bin/podman /usr/bin/podman.orig && \
     # Docker alias

--- a/devspaces-udi/etc/.stow-local-ignore
+++ b/devspaces-udi/etc/.stow-local-ignore
@@ -5,3 +5,6 @@
 # but we don't want them to be symbolic links (or to cause stow conflicts). They will be copied to /home/user/ manually.
 \.bashrc
 \.bash_profile
+
+# Ignore files under .config directory
+\.config

--- a/devspaces-udi/etc/entrypoint.sh
+++ b/devspaces-udi/etc/entrypoint.sh
@@ -145,6 +145,32 @@ mountpoint -q /home/user/ || HOME_USER_MOUNTED=$?
 STOW_COMPLETE=/home/user/.stow_completed
 
 if [ $HOME_USER_MOUNTED -eq 0 ] && [ ! -f $STOW_COMPLETE ]; then
+    # There may be regular, non-symlink files in /home/user that match the
+    # pathing of files in /home/tooling. Stow will error out when it tries to
+    # stow on top of that. Instead, we can append to the current
+    # /home/tooling/.stow-local-ignore file to ignore pre-existing,
+    # non-symlinked files in /home/user that match those in /home/tooling before
+    # we run stow.
+    #
+    # Create two text files containing a sorted path-based list of files in
+    # /home/tooling and /home/user. Cut off "/home/user" and "/home/tooling" and
+    # only get the sub-paths so we can do a proper comparison
+    #
+    # In the case of /home/user, we want regular file types and not symbolic
+    # links.
+    find /home/user -type f -xtype f -print  | sort | sed 's|/home/user||g' > /tmp/user.txt
+    find /home/tooling -print | sort | sed 's|/home/tooling||g' > /tmp/tooling.txt
+    # We compare the two files, trying to find files that exist in /home/user
+    # and /home/tooling. Being that the files that get flagged here are not
+    # already synlinks, we will want to ignore them.
+    IGNORE_FILES="$(comm -12 /tmp/user.txt /tmp/tooling.txt)"
+    # We no longer require the file lists, so remove them
+    rm /tmp/user.txt /tmp/tooling.txt
+    # For each file we need to ignore, append them to
+    # /home/tooling/.stow-local-ignore.
+    for f in $IGNORE_FILES; do echo "${f}" >> /home/tooling/.stow-local-ignore;done
+    # We are now ready to run stow
+    #
     # Create symbolic links from /home/tooling/ -> /home/user/
     stow . -t /home/user/ -d /home/tooling/ --no-folding -v 2 > /tmp/stow.log 2>&1
     # Vim does not permit .viminfo to be a symbolic link for security reasons, so manually copy it

--- a/devspaces-udi/etc/entrypoint.sh
+++ b/devspaces-udi/etc/entrypoint.sh
@@ -118,6 +118,16 @@ else
     ln -f -s /usr/bin/podman.orig /home/tooling/.local/bin/podman
 fi
 
+# Configure container builds to use vfs or fuse-overlayfs
+if [ ! -d "${HOME}/.config/containers" ]; then
+  mkdir -p ${HOME}/.config/containers
+  if [ -c "/dev/fuse" ] && [ -f "/usr/bin/fuse-overlayfs" ]; then
+    (echo '[storage]';echo 'driver = "overlay"';echo '[storage.options.overlay]';echo 'mount_program = "/usr/bin/fuse-overlayfs"') > ${HOME}/.config/containers/storage.conf
+  else
+    (echo '[storage]';echo 'driver = "vfs"') > "${HOME}"/.config/containers/storage.conf
+  fi
+fi
+
 #############################################################################
 # Stow: If persistUserHome is enabled, then the contents of /home/user/
 # will be mounted by a PVC and overwritten. In this case, we use stow to


### PR DESCRIPTION
This PR adds UBI/UDI bug fixes from upstream. They include:

* adds podman 5 support: https://github.com/devfile/developer-images/pull/209
* updates .stow-local-ignore with files in /home/user that would break running stow: https://github.com/devfile/developer-images/pull/196
* automatically detects fuse/vfs: https://github.com/devfile/developer-images/pull/198
