### PR TITLE
Updates virtualenv to version 20.28.0

### DIFF
--- a/devspaces-udi/build/python/requirements-build.txt
+++ b/devspaces-udi/build/python/requirements-build.txt
@@ -14,7 +14,7 @@ attrs==22.1.0
     #   pytest
 cython==0.29.32
     # via -r requirements-build.in
-distlib==0.3.6
+distlib>=0.3.7,<1
     # via virtualenv
 editables==0.3
     # via hatchling
@@ -22,7 +22,7 @@ exceptiongroup==1.0.1
     # via
     #   -r requirements-build.in
     #   pytest
-filelock==3.8.2
+filelock>=3.12.2,<4
     # via virtualenv
 flake8==6.0.0
     # via -r requirements-build.in
@@ -54,7 +54,7 @@ packaging==21.3
     #   setuptools-scm
 pathspec==0.10.2
     # via hatchling
-platformdirs==2.6.0
+platformdirs>=3.9.1,<5
     # via virtualenv
 pluggy==1.0.0
     # via
@@ -101,7 +101,7 @@ typing-extensions==4.4.0
     # via
     #   -r requirements-build.in
     #   setuptools-scm
-virtualenv==20.17.1
+virtualenv==20.28.0
     # via -r requirements-build.in
 wheel==0.38.4
     # via -r requirements-build.in


### PR DESCRIPTION
Virtualenv 20.28.0 dependencies: `distlib`, `filelock`, `platformdirs` were also updated according to: https://github.com/pypa/virtualenv/blob/bfc04e3616d66edc55a31b9627bc5ef35efdf62a/pyproject.toml#L45-L50