### PR TITLE
CRW-8228 update related images to reference devworkspace-rhel9-operator

### DIFF
--- a/devspaces-operator-bundle/container.yaml
+++ b/devspaces-operator-bundle/container.yaml
@@ -53,4 +53,4 @@ operator_manifests:
         devworkspace-operator-bundle-container: devworkspace/devworkspace-operator-bundle
         devworkspace-operator-bundle-package: devworkspace/devworkspace-operator-bundle
         devworkspace-operator-package: devworkspace/devworkspace-operator-bundle
-        devworkspace-operator-container: devworkspace/devworkspace-rhel8-operator
+        devworkspace-operator-container: devworkspace/devworkspace-rhel9-operator


### PR DESCRIPTION
https://issues.redhat.com/browse/CRW-8288

I noticed the DWO operator is out of date.